### PR TITLE
Improve share styling to match NYT Games aesthetic

### DIFF
--- a/src/lib/order/__tests__/shareCard.test.ts
+++ b/src/lib/order/__tests__/shareCard.test.ts
@@ -16,7 +16,7 @@ function createAttempt(feedback: Array<"correct" | "incorrect">): OrderAttempt {
 
 describe("generateArchivalShareText", () => {
   describe("header format", () => {
-    it("shows puzzle number with attempt count: Chrondle: Order #247 1/3", () => {
+    it("shows puzzle number: Chrondle: Order #247", () => {
       const payload: ArchivalSharePayload = {
         puzzleNumber: 247,
         score: { attempts: 1 },
@@ -26,21 +26,7 @@ describe("generateArchivalShareText", () => {
       };
       const result = generateArchivalShareText(payload);
 
-      expect(result).toContain("Chrondle: Order #247 1/3");
-    });
-
-    it("shows correct attempt count for multiple attempts", () => {
-      const payload: ArchivalSharePayload = {
-        puzzleNumber: 100,
-        score: { attempts: 2 },
-        attempts: [
-          createAttempt(["incorrect", "correct", "correct", "correct", "correct", "correct"]),
-          createAttempt(["correct", "correct", "correct", "correct", "correct", "correct"]),
-        ],
-      };
-      const result = generateArchivalShareText(payload);
-
-      expect(result).toContain("Chrondle: Order #100 2/3");
+      expect(result).toContain("Chrondle: Order #247");
     });
   });
 
@@ -146,7 +132,7 @@ describe("generateArchivalShareText", () => {
       };
       const result = generateArchivalShareText(payload);
 
-      expect(result).toContain("chrondle.app");
+      expect(result).toContain("https://chrondle.app");
     });
 
     it("uses custom URL when provided", () => {
@@ -175,10 +161,11 @@ describe("generateArchivalShareText", () => {
       };
       const result = generateArchivalShareText(payload);
 
-      const expected = `Chrondle: Order #247 1/3
+      const expected = `Chrondle: Order #247
+
 🟩🟩🟩🟩🟩🟩
 
-chrondle.app`;
+https://chrondle.app`;
 
       expect(result).toBe(expected);
     });
@@ -195,12 +182,13 @@ chrondle.app`;
       };
       const result = generateArchivalShareText(payload);
 
-      const expected = `Chrondle: Order #247 3/3
+      const expected = `Chrondle: Order #247
+
 ⬜🟩⬜🟩⬜⬜
 ⬜🟩🟩🟩⬜🟩
 🟩🟩🟩🟩🟩🟩
 
-chrondle.app`;
+https://chrondle.app`;
 
       expect(result).toBe(expected);
     });

--- a/src/lib/order/shareCard.ts
+++ b/src/lib/order/shareCard.ts
@@ -24,26 +24,24 @@ export interface ArchivalSharePayload {
  * Generates share text for Order mode.
  *
  * Example:
- * Chrondle: Order #247 2/3
+ * Chrondle: Order #247
+ *
  * ⬜🟩⬜🟩⬜⬜
  * 🟩🟩🟩🟩🟩🟩
  *
- * chrondle.app
+ * https://chrondle.app
  */
 export function generateArchivalShareText(payload: ArchivalSharePayload): string {
   const { puzzleNumber, attempts, url } = payload;
-  const maxAttempts = 3;
 
   // Build attempt progression - each attempt on its own row
   const progressLines = attempts
     .map((attempt) => attempt.feedback.map((f) => (f === "correct" ? "🟩" : "⬜")).join(""))
     .join("\n");
 
-  // Header with attempt count like Wordle "4/6"
-  const attemptCount = attempts.length;
-  let shareText = `Chrondle: Order #${puzzleNumber} ${attemptCount}/${maxAttempts}\n`;
+  let shareText = `Chrondle: Order #${puzzleNumber}\n\n`;
   shareText += `${progressLines}\n\n`;
-  shareText += url || "chrondle.app";
+  shareText += url || "https://chrondle.app";
 
   return shareText;
 }

--- a/src/lib/sharing/__tests__/generator.test.ts
+++ b/src/lib/sharing/__tests__/generator.test.ts
@@ -47,10 +47,10 @@ describe("generateShareText", () => {
       expect(result).toContain("🗓️ 1 year");
     });
 
-    it("combines range and score on one line with bullet separator", () => {
+    it("shows range and score on separate lines", () => {
       const ranges = [createRange(1900, 1914)];
       const result = generateShareText(ranges, 85, true, 347);
-      expect(result).toContain("🗓️ 15 years • ⭐ 85/100");
+      expect(result).toContain("🗓️ 15 years\n⭐ 85/100");
     });
   });
 
@@ -105,7 +105,13 @@ describe("generateShareText", () => {
       const ranges = [createRange(1950, 1950, 0)];
       const result = generateShareText(ranges, 100, true, 347);
 
-      const expected = `Chrondle #347\n⬜⬜⬜⬜⬜⬜\n🗓️ 1 year • 🎯 100/100\n\nchrondle.app`;
+      const expected = `Chrondle #347
+
+⬜⬜⬜⬜⬜⬜
+🗓️ 1 year
+🎯 100/100
+
+https://chrondle.app`;
 
       expect(result).toBe(expected);
     });
@@ -114,7 +120,13 @@ describe("generateShareText", () => {
       const ranges = [createRange(1950, 1960, 3)];
       const result = generateShareText(ranges, 70, true, 123);
 
-      const expected = `Chrondle #123\n🟩🟩🟩⬜⬜⬜\n🗓️ 11 years • 😎 70/100\n\nchrondle.app`;
+      const expected = `Chrondle #123
+
+🟩🟩🟩⬜⬜⬜
+🗓️ 11 years
+😎 70/100
+
+https://chrondle.app`;
 
       expect(result).toBe(expected);
     });

--- a/src/lib/sharing/generator.ts
+++ b/src/lib/sharing/generator.ts
@@ -64,11 +64,12 @@ export function generateShareText(
     // Hints bar as main visual (like Wordle grid)
     const hintsBar = generateHintsBar(hintsUsed);
 
-    // Stats line: 🗓️ 2 years • 🎯 85/100
+    // Stats on separate lines
     const scoreEmoji = getScoreEmoji(totalScore, hasWon);
-    const statsLine = `🗓️ ${widthYears} ${yearLabel} • ${scoreEmoji} ${totalScore}/100`;
+    const rangeLine = `🗓️ ${widthYears} ${yearLabel}`;
+    const scoreLine = `${scoreEmoji} ${totalScore}/100`;
 
-    return `${header}\n${hintsBar}\n${statsLine}\n\nchrondle.app`;
+    return `${header}\n\n${hintsBar}\n${rangeLine}\n${scoreLine}\n\nhttps://chrondle.app`;
   } catch (error) {
     logger.error("Failed to generate share text:", error);
     return `Chrondle: Game complete\nchrondle.app`;


### PR DESCRIPTION
- Regular Chrondle: Clean format with hints bar as visual focus (like
  Wordle grid), combined stats line with bullet separator
- Order mode: Added attempt count (e.g., 2/3) like Wordle's 4/6 format
- Changed hint squares from black (⬛) to green (🟩) for used hints
- Unified URL format (chrondle.app) across both game modes
- Removed verbose labels (Range:, Hints:, Score:) for cleaner look

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated share link URL to use the standard domain format.

* **Improvements**
  * Enhanced share text formatting with emoji visualizations for hints, range, and score.
  * Simplified share text by removing redundant labels for a cleaner, more concise display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->