### PR TITLE
fix(security): derive userId from auth context in submitGuess/submitRange

### DIFF
--- a/src/hooks/actions/useGameActions.ts
+++ b/src/hooks/actions/useGameActions.ts
@@ -169,13 +169,12 @@ export function useGameActions(sources: DataSources): UseGameActionsReturn {
           return false;
         }
 
-        // Validate and assert IDs with proper error handling
+        // Validate and assert puzzle ID
         const validPuzzleId = assertConvexId(puzzle.puzzle.id, "puzzles");
-        const validUserId = assertConvexId(auth.userId, "users");
 
+        // Server derives userId from auth context for security
         await submitGuessMutation({
           puzzleId: validPuzzleId,
-          userId: validUserId,
           guess,
         });
 
@@ -325,11 +324,10 @@ export function useGameActions(sources: DataSources): UseGameActionsReturn {
 
       try {
         const validPuzzleId = assertConvexId(puzzle.puzzle.id, "puzzles");
-        const validUserId = assertConvexId(auth.userId, "users");
 
+        // Server derives userId from auth context for security
         const result = await submitRangeMutation({
           puzzleId: validPuzzleId,
-          userId: validUserId,
           start,
           end,
           hintsUsed: hintLevel,


### PR DESCRIPTION
## Summary

- **Security fix**: Closes broken access control vulnerability where users could manipulate other users' game state
- **Server-side auth**: `submitGuess` and `submitRange` mutations now derive userId from `ctx.auth.getUserIdentity()` instead of accepting it as a client argument
- **Tests updated**: Convex tests use `withIdentity()` to properly mock authentication

## Details

### The Vulnerability (Issue #91)

Both `submitGuess` and `submitRange` mutations accepted `userId` as an argument and used it directly without verifying it matched the authenticated user. This allowed:

```
Attacker authenticates as User A → calls submitGuess with User B's userId → manipulates B's streak, scores, game progress
```

### The Fix

1. **Removed `userId` from mutation args** - no longer accepts client-provided userId
2. **Added auth check** - verifies user is authenticated via `ctx.auth.getUserIdentity()`
3. **Looks up user by clerkId** - derives userId from auth identity's subject field
4. **Updated frontend** - no longer passes userId to mutations

### Files Changed

- `convex/puzzles/mutations.ts` - Security fix for submitGuess and submitRange
- `src/hooks/actions/useGameActions.ts` - Removed userId from mutation calls
- `convex/__tests__/puzzles.convex.test.ts` - Updated tests to use withIdentity()
- `src/hooks/__tests__/id-validation.integration.test.tsx` - Updated test expectations

## Test Plan

- [x] All existing tests pass (1845 passed)
- [x] Type check passes
- [x] Lint passes
- [ ] Manual test: Verify authenticated users can submit guesses for their own games
- [ ] Manual test: Verify users cannot submit guesses for other users (server rejects)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enhanced authorization: User identity verification moved server-side, preventing clients from spoofing identity during puzzle submissions. Authentication now derived from system auth context rather than client-supplied values.

* **Refactor**
  * Simplified API: Removed userId from puzzle submission operations; server now automatically handles user authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->