### PR TITLE
feat: add welcome modal for first-time visitors

### DIFF
--- a/src/components/GamesGallery.tsx
+++ b/src/components/GamesGallery.tsx
@@ -8,6 +8,7 @@ import { ArrowRight, Crosshair, Shuffle, GripHorizontal, Crown, Sun, Moon } from
 import { setModePreferenceCookie, type ModeKey } from "@/lib/modePreference";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/components/SessionThemeProvider";
+import { WelcomeModal, WELCOME_SEEN_KEY } from "@/components/WelcomeModal";
 
 // --- Configuration ---
 
@@ -71,6 +72,21 @@ export function GamesGallery() {
   const [activeKey, setActiveKey] = useState<ModeKey | null>("classic");
   const { currentTheme, toggle, isMounted } = useTheme();
   const [isMobile, setIsMobile] = useState(false);
+  const [showWelcome, setShowWelcome] = useState(false);
+
+  // Check if first-time visitor on mount (after hydration)
+  useEffect(() => {
+    if (!isMounted) return;
+    const hasSeenWelcome = localStorage.getItem(WELCOME_SEEN_KEY);
+    if (!hasSeenWelcome) {
+      setShowWelcome(true);
+    }
+  }, [isMounted]);
+
+  const handleWelcomeDismiss = useCallback(() => {
+    localStorage.setItem(WELCOME_SEEN_KEY, "true");
+    setShowWelcome(false);
+  }, []);
 
   // Mobile detection for responsive layout adjustments
   useEffect(() => {
@@ -94,6 +110,8 @@ export function GamesGallery() {
 
   return (
     <main className="bg-background relative flex h-[100dvh] w-full flex-col overflow-hidden md:flex-row">
+      <WelcomeModal open={showWelcome} onDismiss={handleWelcomeDismiss} />
+
       {/* --- Branding Anchor with Theme Toggle --- */}
       <div
         className={cn(

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Crown, Calendar, Target, Lightbulb } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface WelcomeModalProps {
+  open: boolean;
+  onDismiss: () => void;
+}
+
+export const WELCOME_SEEN_KEY = "chrondle_seen_welcome";
+
+export function WelcomeModal({ open, onDismiss }: WelcomeModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onDismiss()}>
+      <DialogContent className="sm:max-w-md" showCloseButton={false}>
+        <DialogHeader className="text-center sm:text-center">
+          <div className="bg-primary/10 mx-auto mb-4 flex size-12 items-center justify-center rounded-sm">
+            <Crown className="text-primary size-6" />
+          </div>
+          <DialogTitle className="font-display text-2xl text-balance">
+            Test Your History Knowledge
+          </DialogTitle>
+          <DialogDescription className="text-base text-pretty">
+            Six clues. One year. Daily puzzles from ancient empires to pop culture.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="my-4 space-y-3">
+          <div className="flex items-start gap-3">
+            <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-sm">
+              <Calendar className="text-muted-foreground size-4" />
+            </div>
+            <p className="text-muted-foreground text-sm">A new puzzle every day at midnight</p>
+          </div>
+
+          <div className="flex items-start gap-3">
+            <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-sm">
+              <Lightbulb className="text-muted-foreground size-4" />
+            </div>
+            <p className="text-muted-foreground text-sm">
+              Reveal hints one by one to narrow down the year
+            </p>
+          </div>
+
+          <div className="flex items-start gap-3">
+            <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-sm">
+              <Target className="text-muted-foreground size-4" />
+            </div>
+            <p className="text-muted-foreground text-sm">Fewer hints used means a higher score</p>
+          </div>
+        </div>
+
+        <Button onClick={onDismiss} className="w-full" size="lg">
+          Start Playing
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/__tests__/GamesGallery.test.tsx
+++ b/src/components/__tests__/GamesGallery.test.tsx
@@ -25,6 +25,14 @@ vi.mock("@/lib/modePreference", () => ({
   setModePreferenceCookie: vi.fn(),
 }));
 
+// Mock WelcomeModal to avoid localStorage complexity in GamesGallery tests
+vi.mock("@/components/WelcomeModal", () => ({
+  WelcomeModal: function MockWelcomeModal() {
+    return null;
+  },
+  WELCOME_SEEN_KEY: "chrondle_seen_welcome",
+}));
+
 // Mock motion/react - use function syntax for React access
 vi.mock("motion/react", () => {
   // Use factory function that returns mocks
@@ -95,6 +103,18 @@ vi.mock("lucide-react", () => ({
   },
   Moon: function Moon() {
     return React.createElement("span", { "data-testid": "moon" }, "☽");
+  },
+  Calendar: function Calendar() {
+    return React.createElement("span", { "data-testid": "calendar" }, "📅");
+  },
+  Target: function Target() {
+    return React.createElement("span", { "data-testid": "target" }, "🎯");
+  },
+  Lightbulb: function Lightbulb() {
+    return React.createElement("span", { "data-testid": "lightbulb" }, "💡");
+  },
+  XIcon: function XIcon() {
+    return React.createElement("span", { "data-testid": "x-icon" }, "✕");
   },
 }));
 

--- a/src/components/__tests__/WelcomeModal.test.tsx
+++ b/src/components/__tests__/WelcomeModal.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { WelcomeModal, WELCOME_SEEN_KEY } from "../WelcomeModal";
+
+// Mock lucide-react icons
+vi.mock("lucide-react", () => ({
+  Crown: function Crown() {
+    return React.createElement("span", { "data-testid": "crown" }, "♛");
+  },
+  Calendar: function Calendar() {
+    return React.createElement("span", { "data-testid": "calendar" }, "📅");
+  },
+  Target: function Target() {
+    return React.createElement("span", { "data-testid": "target" }, "🎯");
+  },
+  Lightbulb: function Lightbulb() {
+    return React.createElement("span", { "data-testid": "lightbulb" }, "💡");
+  },
+  XIcon: function XIcon() {
+    return React.createElement("span", { "data-testid": "x-icon" }, "✕");
+  },
+}));
+
+describe("WelcomeModal", () => {
+  const mockOnDismiss = vi.fn();
+
+  beforeEach(() => {
+    mockOnDismiss.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("Rendering", () => {
+    it("renders modal when open is true", () => {
+      render(<WelcomeModal open={true} onDismiss={mockOnDismiss} />);
+
+      expect(screen.getByText("Test Your History Knowledge")).toBeInTheDocument();
+    });
+
+    it("does not render modal when open is false", () => {
+      render(<WelcomeModal open={false} onDismiss={mockOnDismiss} />);
+
+      expect(screen.queryByText("Test Your History Knowledge")).not.toBeInTheDocument();
+    });
+
+    it("renders the tagline", () => {
+      render(<WelcomeModal open={true} onDismiss={mockOnDismiss} />);
+
+      expect(
+        screen.getByText(
+          /Six clues\. One year\. Daily puzzles from ancient empires to pop culture\./,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("renders game explanation bullet points", () => {
+      render(<WelcomeModal open={true} onDismiss={mockOnDismiss} />);
+
+      expect(screen.getByText("A new puzzle every day at midnight")).toBeInTheDocument();
+      expect(
+        screen.getByText("Reveal hints one by one to narrow down the year"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Fewer hints used means a higher score")).toBeInTheDocument();
+    });
+
+    it("renders Start Playing CTA button", () => {
+      render(<WelcomeModal open={true} onDismiss={mockOnDismiss} />);
+
+      expect(screen.getByRole("button", { name: /start playing/i })).toBeInTheDocument();
+    });
+
+    it("renders Crown icon in header", () => {
+      render(<WelcomeModal open={true} onDismiss={mockOnDismiss} />);
+
+      expect(screen.getByTestId("crown")).toBeInTheDocument();
+    });
+  });
+
+  describe("Interaction", () => {
+    it("calls onDismiss when Start Playing button is clicked", () => {
+      render(<WelcomeModal open={true} onDismiss={mockOnDismiss} />);
+
+      const startButton = screen.getByRole("button", { name: /start playing/i });
+      fireEvent.click(startButton);
+
+      expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Constants", () => {
+    it("exports WELCOME_SEEN_KEY constant", () => {
+      expect(WELCOME_SEEN_KEY).toBe("chrondle_seen_welcome");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add welcome modal that appears once for first-time visitors
- Introduces Chrondle's value proposition before they interact with mode selector
- Persists seen state in localStorage (`chrondle_seen_welcome`)

## Changes
- New `WelcomeModal` component using existing Radix Dialog primitives
- Integration into `GamesGallery` with hydration-safe localStorage check
- Comprehensive unit tests for modal behavior

## Test Plan
- [x] Modal appears on first visit (clear localStorage, refresh)
- [x] Modal does not appear on subsequent visits
- [x] "Start Playing" dismisses modal and sets localStorage flag
- [x] Unit tests pass
- [x] Build succeeds
- [x] Type check passes

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added welcome modal for first-time visitors displaying game information and tips
  * Modal persists dismissal preference so it won't appear again on return visits

* **Tests**
  * Added comprehensive test coverage for new welcome modal functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->