### PR TITLE
feat(analytics): add PostHog user identification

### DIFF
--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ClerkProvider, useAuth } from "@clerk/nextjs";
+import { PostHogIdentify } from "@/components/providers/PostHogIdentify";
 import { ConvexReactClient } from "convex/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { SessionThemeProvider } from "@/components/SessionThemeProvider";
@@ -106,6 +107,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <ToastProvider>
         <MigrationProvider>
           <ClerkProvider publishableKey={clerkKey} dynamic>
+            <PostHogIdentify />
             <ConvexProviderWithClerk client={convex!} useAuth={useAuth}>
               <UserCreationProvider>
                 <SessionThemeProvider>{children}</SessionThemeProvider>

--- a/src/components/providers/PostHogIdentify.tsx
+++ b/src/components/providers/PostHogIdentify.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import { useUser } from "@clerk/nextjs";
+
+// Lazy-loaded PostHog getter - matches PostHogProvider pattern
+let posthogPromise: Promise<typeof import("posthog-js")> | null = null;
+
+function getPostHog() {
+  if (!posthogPromise) {
+    posthogPromise = import("posthog-js");
+  }
+  return posthogPromise;
+}
+
+/**
+ * Identifies the current user to PostHog for analytics.
+ * Must be rendered inside both ClerkProvider and PostHogProvider.
+ */
+export function PostHogIdentify() {
+  const { user, isLoaded } = useUser();
+
+  useEffect(() => {
+    if (!isLoaded) return;
+
+    getPostHog().then(({ default: posthog }) => {
+      if (user) {
+        posthog.identify(user.id, {
+          created_at: user.createdAt
+            ? new Date(user.createdAt).toISOString()
+            : undefined,
+        });
+      } else if (posthog._isIdentified?.()) {
+        posthog.reset();
+      }
+    });
+  }, [user, isLoaded]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Adds PostHog user identification to link Clerk authenticated users with their PostHog analytics profiles.

## Changes
- Added `PostHogIdentify` component using lazy-loading pattern (matches existing PostHogProvider)
- Integrated into the Providers component inside ClerkProvider
- Resets PostHog identity on logout

## Why
This enables:
- User-level analytics and journey tracking
- Cohort analysis based on user properties
- Feature flag targeting by user
- Session replay tied to specific users

## Testing
- Verified component renders without errors
- User ID flows through on authentication