### PR TITLE
fix(ci): use GH_RELEASE_TOKEN for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Release
         id: semantic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
         run: pnpm exec semantic-release
 
   synthesize:
@@ -78,6 +78,6 @@ jobs:
 
       - name: Synthesize user-friendly notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: node scripts/synthesize-release-notes.mjs ${{ needs.release.outputs.new_release_version }}


### PR DESCRIPTION
## Problem
semantic-release uses `GITHUB_TOKEN` which is the github-actions[bot] token. Our org-wide branch protection ruleset requires PRs to push to master. When semantic-release tries to push version bumps + CHANGELOG.md, it gets rejected (GH013).

## Fix
Use `GH_RELEASE_TOKEN` org secret (kaylee-mistystep's token with admin bypass rights) instead of `GITHUB_TOKEN` for the release step.

## Context
- Org ruleset: Production Branch Protection (ID 12509021)
- Only admin roles can bypass the PR requirement
- `GH_RELEASE_TOKEN` is set as an org-wide secret with visibility to all repos