### PR TITLE
ci: increase Cerberus timeout

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -33,7 +33,9 @@ jobs:
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer OPENROUTER_API_KEY (OpenRouter). Fallback supports legacy secret name.
           api-key: ${{ secrets.OPENROUTER_API_KEY || secrets.MOONSHOT_API_KEY }}
+          # 1800s (30m): default 600s caused consistent SKIPs on PRs #178/#179.
           timeout: "1800"
 
   verdict:


### PR DESCRIPTION
Cerberus has been running, but reviewers consistently `SKIP` due to the default 600s timeout (`opencode` exit=124), so it looks like the council isn't actually reviewing (e.g. PRs #178/#179).

Changes:
- Increase per-reviewer timeout to 1800s
- Use `api-key` input (OpenRouter) with fallback to existing `MOONSHOT_API_KEY`
- Trigger on `ready_for_review`
- Fail the council job when all reviewers `SKIP` (clearer UX)
