### PR TITLE
fix(ci): restore bundle size monitoring with correct webpack output paths

### DIFF
--- a/.size-limit.mjs
+++ b/.size-limit.mjs
@@ -1,20 +1,16 @@
 export default [
   {
     name: "All JS Chunks",
-    path: ".next/static/chunks/*.js",
-    limit: "900 KB", // Increased from 830 KB to accommodate PostHog (~50 KB)
+    path: ".next/static/chunks/**/*.js",
+    limit: "900 KB",
     gzip: true,
-  },
-  {
-    name: "Turbopack Runtime",
-    path: ".next/static/chunks/turbopack-*.js",
-    limit: "10 KB",
-    gzip: true,
+    running: false,
   },
   {
     name: "CSS Bundle",
     path: ".next/static/chunks/*.css",
     limit: "150 KB",
     gzip: true,
+    running: false,
   },
 ];


### PR DESCRIPTION
## Summary

Bundle size monitoring in CI was silently broken. The `.size-limit.mjs` glob patterns targeted Turbopack-style chunk paths, but production builds use Webpack — causing size-limit to report "can't find files" and skip enforcement entirely. No bundle regressions were being caught on PRs.

Closes #119

## Changes

- **`.size-limit.mjs`** — Updated JS glob from `.next/static/chunks/*.js` → `.next/static/chunks/**/*.js` to match Webpack's nested output structure
- Removed the `Turbopack Runtime` entry (Turbopack-specific, not relevant to production builds)
- Added `running: false` to both entries — CI builds the app separately via `build_script: build`; size-limit should only measure, not re-build

## Acceptance Criteria

- [x] `pnpm size` resolves files without "can't find files" error
- [x] Bundle size CI step posts results on PRs
- [x] 900 KB JS limit and 150 KB CSS limit are actively enforced
- [x] No Turbopack-only config left in production monitoring

## Manual QA

```bash
# 1. Build production bundle
pnpm build

# 2. Run size-limit directly — should find files and report sizes, not error
pnpm size

# Expected: two rows (All JS Chunks, CSS Bundle) with sizes and pass/fail
# Not expected: "Size Limit can't find files at..."
```

To verify CI: open a PR against master and confirm the Bundle Size Analysis workflow posts a comment with size deltas.

## Before / After

**Before:** `.size-limit.mjs` used `*.js` (flat) and included a `Turbopack Runtime` entry. Production builds (Webpack) output chunks in nested subdirectories like `.next/static/chunks/app/`, `.next/static/chunks/pages/`, etc. — none matched the flat glob. Result: `Size Limit can't find files` on every CI run, 0 KB measured, no enforcement.

**After:** Glob is `**/*.js` (recursive), capturing all Webpack output regardless of nesting depth. `running: false` prevents double-builds. Turbopack entry removed. Monitoring works.

## Test Coverage

This change is CI/tooling configuration — no application logic changed, no unit tests apply.

The fix is verified by `pnpm build && pnpm size` resolving files successfully. CI behavior is verified by the Bundle Size Analysis workflow completing without errors on this PR.