### PR TITLE
Add analytics endpoint configuration and payload formatting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,10 @@ NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.1
 NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0.1
 
 # PostHog Analytics
+# Analytics sink for queued game events.
+# - Use /ingest/batch to send via PostHog reverse proxy (recommended)
+# - Can point to any JSON endpoint that accepts { events } payload.
+NEXT_PUBLIC_ANALYTICS_ENDPOINT=/ingest/batch
 NEXT_PUBLIC_POSTHOG_KEY=phc_...
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -25,6 +25,28 @@ Environment variables required for observability:
 | `NEXT_PUBLIC_SENTRY_RELEASE`     | Release identifier (commit SHA).                      | CI/Prod    |
 | `ORDER_FAILURE_SLACK_WEBHOOK`    | Webhook URL for critical order failure alerts.        | Optional   |
 
+## Game Analytics Verification
+
+- `GameAnalytics` uses `NEXT_PUBLIC_ANALYTICS_ENDPOINT` to flush event batches from the client.
+- Set this to `/ingest/batch` for PostHog (batches are transformed in `src/lib/analytics.ts`).
+- Optional fallback/custom backends should accept:
+
+  ```json
+  { "events": [ ...AnalyticsEventData... ] }
+  ```
+
+### Launch validation checklist
+
+- Confirm events are being captured in PostHog (or your backend) for:
+  - `game_loaded`
+  - `game_completed`
+  - `guess_submitted`
+  - `state_divergence`
+- Confirm these dashboard metrics can be calculated:
+  - Daily active users from `game_loaded` deduped by `session_id`
+  - Completion rate: `count(game_completed where won=true) / count(game_completed)`
+  - Average guesses to solve from `guess_submitted` grouped by puzzle
+
 ## Usage
 
 ### Client-Side Mutations

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -43,7 +43,7 @@ Environment variables required for observability:
   - `guess_submitted`
   - `state_divergence`
 - Confirm these dashboard metrics can be calculated:
-  - Daily active users from `game_loaded` deduped by `session_id`
+  - Daily active users from `game_loaded` deduped by `distinct_id`
   - Completion rate: `count(game_completed where won=true) / count(game_completed)`
   - Average guesses to solve from `guess_submitted` grouped by puzzle
 

--- a/package.json
+++ b/package.json
@@ -177,6 +177,5 @@
     "protobufjs",
     "sharp",
     "unrs-resolver"
-  ],
-  "packageManager": "pnpm@10.30.1+sha512.3590e550d5384caa39bd5c7c739f72270234b2f6059e13018f975c313b1eb9fefcc09714048765d4d9efe961382c312e624572c0420762bdc5d5940cdf9be73a"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -177,5 +177,6 @@
     "protobufjs",
     "sharp",
     "unrs-resolver"
-  ]
+  ],
+  "packageManager": "pnpm@10.30.1+sha512.3590e550d5384caa39bd5c7c739f72270234b2f6059e13018f975c313b1eb9fefcc09714048765d4d9efe961382c312e624572c0420762bdc5d5940cdf9be73a"
 }

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -4,7 +4,7 @@ import { GameAnalytics, AnalyticsEvent } from "../analytics";
 import type { GameState } from "@/types/gameState";
 
 const mockCapture = vi.hoisted(() => vi.fn());
-const mockGetDistinctId = vi.hoisted(() => vi.fn(() => undefined));
+const mockGetDistinctId = vi.hoisted(() => vi.fn<() => string | undefined>(() => undefined));
 
 vi.mock("posthog-js", () => ({
   default: {

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -19,6 +19,7 @@ global.fetch = mockFetch;
 describe("GameAnalytics", () => {
   let analytics: GameAnalytics;
   const originalEndpoint = process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT;
+  const originalPayloadFormat = process.env.NEXT_PUBLIC_ANALYTICS_FORMAT;
   const originalPosthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
   beforeEach(() => {
@@ -47,6 +48,12 @@ describe("GameAnalytics", () => {
       delete process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT;
     } else {
       process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = originalEndpoint;
+    }
+
+    if (originalPayloadFormat === undefined) {
+      delete process.env.NEXT_PUBLIC_ANALYTICS_FORMAT;
+    } else {
+      process.env.NEXT_PUBLIC_ANALYTICS_FORMAT = originalPayloadFormat;
     }
 
     if (originalPosthogKey === undefined) {
@@ -588,6 +595,43 @@ describe("GameAnalytics", () => {
       expect(payload.api_key).toBeUndefined();
     });
 
+    it("should honor explicit payload format override", () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = "/ingest/batch";
+      process.env.NEXT_PUBLIC_ANALYTICS_FORMAT = "events";
+      delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { source: "format-override" }, "user-123", 3);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const payload = JSON.parse(init.body as string);
+
+      expect(url).toBe("/ingest/batch");
+      expect(payload).toEqual(
+        expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({
+              event: AnalyticsEvent.GAME_LOADED,
+              userId: "user-123",
+              puzzleNumber: 3,
+            }),
+          ]),
+        }),
+      );
+      expect(payload.api_key).toBeUndefined();
+    });
+
     it("should drop events when PostHog key is missing to avoid retry loop", () => {
       delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
       process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = "/ingest/batch";
@@ -672,6 +716,26 @@ describe("GameAnalytics", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
       expect(init.keepalive).toBe(true);
+    });
+
+    it("should keep queued events when endpoint is missing", () => {
+      delete process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT;
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 100,
+        flushInterval: 60000,
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { source: "no-endpoint" });
+      window.dispatchEvent(new Event("beforeunload"));
+
+      const summary = analytics.getSummary();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(summary.queueSize).toBe(1);
     });
   });
 

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -607,6 +607,72 @@ describe("GameAnalytics", () => {
       expect(mockFetch).not.toHaveBeenCalled();
       expect(summary.queueSize).toBe(0);
     });
+
+    it("should cap queue growth when flush retries keep failing", async () => {
+      mockFetch.mockRejectedValue(new Error("network down"));
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        maxQueueSize: 2,
+        flushInterval: 60000,
+        endpoint: "https://analytics.example.test/v1/events",
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { n: 1 });
+      await Promise.resolve();
+      analytics.track(AnalyticsEvent.GAME_STARTED, { n: 2 });
+      await Promise.resolve();
+      analytics.track(AnalyticsEvent.HINT_VIEWED, { n: 3 });
+      await Promise.resolve();
+
+      const summary = analytics.getSummary();
+      expect(summary.queueSize).toBe(2);
+    });
+
+    it("should omit keepalive on regular interval flushes", () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+        endpoint: "https://analytics.example.test/v1/events",
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { source: "interval" });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.keepalive).toBeUndefined();
+    });
+
+    it("should use keepalive for beforeunload flush", () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 100,
+        flushInterval: 60000,
+        endpoint: "https://analytics.example.test/v1/events",
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { source: "beforeunload" });
+      window.dispatchEvent(new Event("beforeunload"));
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.keepalive).toBe(true);
+    });
   });
 
   describe("reset", () => {

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -484,6 +484,9 @@ describe("GameAnalytics", () => {
           }),
         }),
       );
+
+      await Promise.resolve();
+      expect(mockCapture).not.toHaveBeenCalled();
     });
 
     it("should send raw { events } payload for custom endpoint", async () => {
@@ -559,7 +562,7 @@ describe("GameAnalytics", () => {
       expect(payload.api_key).toBeUndefined();
     });
 
-    it("should requeue events when PostHog request cannot be built", () => {
+    it("should drop events when PostHog key is missing to avoid retry loop", () => {
       delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
       process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = "/ingest/batch";
       (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
@@ -576,7 +579,7 @@ describe("GameAnalytics", () => {
 
       const summary = analytics.getSummary();
       expect(mockFetch).not.toHaveBeenCalled();
-      expect(summary.queueSize).toBe(1);
+      expect(summary.queueSize).toBe(0);
     });
   });
 

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -18,6 +18,8 @@ global.fetch = mockFetch;
 
 describe("GameAnalytics", () => {
   let analytics: GameAnalytics;
+  const originalEndpoint = process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT;
+  const originalPosthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -38,6 +40,18 @@ describe("GameAnalytics", () => {
   afterEach(() => {
     analytics.reset();
     vi.clearAllTimers();
+
+    if (originalEndpoint === undefined) {
+      delete process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT;
+    } else {
+      process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = originalEndpoint;
+    }
+
+    if (originalPosthogKey === undefined) {
+      delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    } else {
+      process.env.NEXT_PUBLIC_POSTHOG_KEY = originalPosthogKey;
+    }
   });
 
   describe("getInstance", () => {
@@ -424,6 +438,85 @@ describe("GameAnalytics", () => {
 
       const summary = sampledAnalytics.getSummary();
       expect(summary.queueSize).toBe(0);
+    });
+  });
+
+  describe("flush", () => {
+    it("should send PostHog batch payload for ingest endpoint", async () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = "/ingest/batch";
+      process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key";
+
+      // Reset with config that will flush on first tracked event.
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { difficulty: "easy" }, "user-123", 42);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const payload = JSON.parse(init.body as string);
+
+      expect(url).toBe("/ingest/batch");
+      expect(payload.api_key).toBe("phc_test_key");
+      expect(payload.v).toBe(1);
+      expect(payload.batch).toHaveLength(1);
+      expect(payload.batch[0]).toEqual(
+        expect.objectContaining({
+          event: AnalyticsEvent.GAME_LOADED,
+          distinct_id: "user-123",
+          properties: expect.objectContaining({
+            event_name: AnalyticsEvent.GAME_LOADED,
+            difficulty: "easy",
+            puzzle_number: 42,
+          }),
+        }),
+      );
+    });
+
+    it("should send raw { events } payload for custom endpoint", async () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+        endpoint: "https://analytics.example.test/v1/events",
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { difficulty: "medium" }, "user-456", 7);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const payload = JSON.parse(init.body as string);
+
+      expect(url).toBe("https://analytics.example.test/v1/events");
+      expect(payload).toEqual(
+        expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({
+              event: AnalyticsEvent.GAME_LOADED,
+              userId: "user-456",
+              sessionId: expect.any(String),
+              puzzleNumber: 7,
+              properties: expect.objectContaining({
+                difficulty: "medium",
+              }),
+            }),
+          ]),
+        }),
+      );
     });
   });
 

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -826,6 +826,69 @@ describe("GameAnalytics", () => {
       expect(init.keepalive).toBe(true);
     });
 
+    it("should use keepalive for visibilitychange flush", () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      const originalVisibilityState = Object.getOwnPropertyDescriptor(document, "visibilityState");
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "hidden",
+      });
+
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 100,
+        flushInterval: 60000,
+        endpoint: "https://analytics.example.test/v1/events",
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { source: "visibilitychange" });
+      window.dispatchEvent(new Event("visibilitychange"));
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.keepalive).toBe(true);
+
+      if (originalVisibilityState) {
+        Object.defineProperty(document, "visibilityState", originalVisibilityState);
+      } else {
+        delete (document as { visibilityState?: string }).visibilityState;
+      }
+    });
+
+    it("should cap keepalive flush batch size to avoid oversized payloads", () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 200,
+        flushInterval: 60000,
+        endpoint: "https://analytics.example.test/v1/events",
+      });
+
+      for (let index = 0; index < 120; index += 1) {
+        analytics.track(AnalyticsEvent.GAME_LOADED, { index });
+      }
+      window.dispatchEvent(new Event("beforeunload"));
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const payload = JSON.parse(init.body as string) as {
+        events: Array<{ properties?: { index?: number } }>;
+      };
+      expect(payload.events).toHaveLength(50);
+      expect(payload.events[0]?.properties?.index).toBe(0);
+      expect(payload.events[49]?.properties?.index).toBe(49);
+
+      const summary = analytics.getSummary();
+      expect(summary.queueSize).toBe(70);
+    });
+
     it("should keep queued events when endpoint is missing", () => {
       delete process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT;
       (GameAnalytics as unknown as { instance: undefined }).instance = undefined;

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -4,10 +4,12 @@ import { GameAnalytics, AnalyticsEvent } from "../analytics";
 import type { GameState } from "@/types/gameState";
 
 const mockCapture = vi.hoisted(() => vi.fn());
+const mockGetDistinctId = vi.hoisted(() => vi.fn(() => undefined));
 
 vi.mock("posthog-js", () => ({
   default: {
     capture: mockCapture,
+    get_distinct_id: mockGetDistinctId,
     __loaded: true,
   },
 }));
@@ -520,6 +522,31 @@ describe("GameAnalytics", () => {
       const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
       const payload = JSON.parse(init.body as string);
       expect(payload.batch[0].distinct_id).toBe("anon_test_123");
+    });
+
+    it("should prefer PostHog SDK distinct_id for batch payloads", async () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = "/ingest/batch";
+      process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key";
+      mockGetDistinctId.mockReturnValue("ph_distinct_123");
+
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 100,
+        flushInterval: 60000,
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { source: "sdk-distinct-id" });
+      await Promise.resolve();
+      window.dispatchEvent(new Event("beforeunload"));
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const payload = JSON.parse(init.body as string);
+      expect(payload.batch[0].distinct_id).toBe("ph_distinct_123");
     });
 
     it("should send raw { events } payload for custom endpoint", async () => {

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -595,7 +595,7 @@ describe("GameAnalytics", () => {
       expect(payload.api_key).toBeUndefined();
     });
 
-    it("should honor explicit payload format override", () => {
+    it("should honor explicit payload format override", async () => {
       mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
       process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = "/ingest/batch";
       process.env.NEXT_PUBLIC_ANALYTICS_FORMAT = "events";
@@ -630,6 +630,52 @@ describe("GameAnalytics", () => {
         }),
       );
       expect(payload.api_key).toBeUndefined();
+
+      await Promise.resolve();
+      expect(mockCapture).toHaveBeenCalledWith(
+        AnalyticsEvent.GAME_LOADED,
+        expect.objectContaining({
+          source: "format-override",
+        }),
+      );
+    });
+
+    it("should skip direct PostHog capture for explicit posthog-batch override", async () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = "https://analytics.example.test/v1/events";
+      process.env.NEXT_PUBLIC_ANALYTICS_FORMAT = "posthog-batch";
+      process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key";
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+      });
+
+      analytics.track(AnalyticsEvent.GAME_STARTED, { source: "batch-override" }, "user-999", 5);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const payload = JSON.parse(init.body as string);
+      expect(url).toBe("https://analytics.example.test/v1/events");
+      expect(payload).toEqual(
+        expect.objectContaining({
+          api_key: "phc_test_key",
+          batch: expect.arrayContaining([
+            expect.objectContaining({
+              event: AnalyticsEvent.GAME_STARTED,
+              distinct_id: "user-999",
+            }),
+          ]),
+          v: 1,
+        }),
+      );
+
+      await Promise.resolve();
+      expect(mockCapture).not.toHaveBeenCalled();
     });
 
     it("should drop events when PostHog key is missing to avoid retry loop", () => {

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -23,6 +23,7 @@ describe("GameAnalytics", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.removeItem("chrondle-anonymous-id");
 
     // Reset singleton
     (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
@@ -40,6 +41,7 @@ describe("GameAnalytics", () => {
   afterEach(() => {
     analytics.reset();
     vi.clearAllTimers();
+    window.localStorage.removeItem("chrondle-anonymous-id");
 
     if (originalEndpoint === undefined) {
       delete process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT;
@@ -487,6 +489,30 @@ describe("GameAnalytics", () => {
 
       await Promise.resolve();
       expect(mockCapture).not.toHaveBeenCalled();
+    });
+
+    it("should use persistent anonymous id for PostHog distinct_id", () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = "/ingest/batch";
+      process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key";
+      window.localStorage.setItem("chrondle-anonymous-id", "anon_test_123");
+
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { difficulty: "anon" });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const payload = JSON.parse(init.body as string);
+      expect(payload.batch[0].distinct_id).toBe("anon_test_123");
     });
 
     it("should send raw { events } payload for custom endpoint", async () => {

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -457,7 +457,12 @@ describe("GameAnalytics", () => {
         flushInterval: 60000,
       });
 
-      analytics.track(AnalyticsEvent.GAME_LOADED, { difficulty: "easy" }, "user-123", 42);
+      analytics.track(
+        AnalyticsEvent.GAME_LOADED,
+        { difficulty: "easy", event_name: "should_not_override" },
+        "user-123",
+        42,
+      );
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
@@ -517,6 +522,61 @@ describe("GameAnalytics", () => {
           ]),
         }),
       );
+    });
+
+    it("should treat ingest-like custom endpoint as raw events payload", async () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+        endpoint: "https://analytics.example.test/v1/ingest/events",
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { source: "custom" }, "user-789", 9);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const payload = JSON.parse(init.body as string);
+
+      expect(url).toBe("https://analytics.example.test/v1/ingest/events");
+      expect(payload).toEqual(
+        expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({
+              event: AnalyticsEvent.GAME_LOADED,
+              userId: "user-789",
+            }),
+          ]),
+        }),
+      );
+      expect(payload.api_key).toBeUndefined();
+    });
+
+    it("should requeue events when PostHog request cannot be built", () => {
+      delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+      process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT = "/ingest/batch";
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { source: "missing-key" });
+
+      const summary = analytics.getSummary();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(summary.queueSize).toBe(1);
     });
   });
 

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -826,6 +826,45 @@ describe("GameAnalytics", () => {
       expect(init.keepalive).toBe(true);
     });
 
+    it("should allow keepalive flush while regular flush is in progress", async () => {
+      let resolveFirst: (value: Response) => void = () => {};
+      const firstFetch = new Promise<Response>((resolve) => {
+        resolveFirst = resolve;
+      });
+
+      mockFetch.mockImplementationOnce(() => firstFetch);
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+        endpoint: "https://analytics.example.test/v1/events",
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { seq: 1 });
+      analytics.track(AnalyticsEvent.GAME_STARTED, { seq: 2 });
+
+      window.dispatchEvent(new Event("beforeunload"));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [, secondInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+      expect(secondInit.keepalive).toBe(true);
+
+      const payload = JSON.parse(secondInit.body as string) as {
+        events: Array<{ properties?: { seq?: number } }>;
+      };
+      expect(payload.events.map((event) => event.properties?.seq)).toEqual([2]);
+
+      resolveFirst(new Response(null, { status: 200 }));
+      await Promise.resolve();
+    });
+
     it("should use keepalive for visibilitychange flush", () => {
       mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
       const originalVisibilityState = Object.getOwnPropertyDescriptor(document, "visibilityState");

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -677,6 +677,68 @@ describe("GameAnalytics", () => {
       expect(summary.queueSize).toBe(2);
     });
 
+    it("should retry transient server errors (5xx)", async () => {
+      mockFetch.mockResolvedValue(new Response("server error", { status: 503 }));
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+        endpoint: "https://analytics.example.test/v1/events",
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { source: "retry-5xx" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const summary = analytics.getSummary();
+      expect(summary.queueSize).toBe(1);
+    });
+
+    it("should preserve event order when requeueing failed flushes", async () => {
+      let rejectFirst: (reason?: unknown) => void = () => {};
+      const firstFetch = new Promise<Response>((_resolve, reject) => {
+        rejectFirst = reject;
+      });
+
+      mockFetch.mockImplementationOnce(() => firstFetch);
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+
+      (GameAnalytics as unknown as { instance: undefined }).instance = undefined;
+
+      analytics = GameAnalytics.getInstance({
+        enabled: true,
+        debugMode: false,
+        sampleRate: 1,
+        batchSize: 1,
+        flushInterval: 60000,
+        endpoint: "https://analytics.example.test/v1/events",
+      });
+
+      analytics.track(AnalyticsEvent.GAME_LOADED, { seq: 1 });
+      analytics.track(AnalyticsEvent.GAME_STARTED, { seq: 2 });
+
+      rejectFirst(new Error("network down"));
+      await Promise.resolve();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      window.dispatchEvent(new Event("beforeunload"));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [, secondInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+      const payload = JSON.parse(secondInit.body as string) as {
+        events: Array<{ properties?: { seq?: number } }>;
+      };
+
+      expect(payload.events.map((event) => event.properties?.seq)).toEqual([1, 2]);
+    });
+
     it("should omit keepalive on regular interval flushes", () => {
       mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
       (GameAnalytics as unknown as { instance: undefined }).instance = undefined;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -113,6 +113,7 @@ export class GameAnalytics {
   private eventQueue: AnalyticsEventData[] = [];
   private sessionId: string;
   private anonymousId?: string;
+  private posthogDistinctId?: string;
   private lastState: GameState | null = null;
   private stateHistory: StateTransition[] = [];
   private flushTimer?: NodeJS.Timeout;
@@ -150,6 +151,7 @@ export class GameAnalytics {
 
     // Bind window events for cleanup
     if (typeof window !== "undefined") {
+      this.syncDistinctIdFromPostHog();
       window.addEventListener("beforeunload", () => this.flush({ keepalive: true }));
       window.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "hidden") {
@@ -396,6 +398,10 @@ export class GameAnalytics {
     puzzleNumber?: number,
   ): void {
     if (!this.config.enabled) return;
+
+    if (typeof window !== "undefined") {
+      this.syncDistinctIdFromPostHog();
+    }
 
     // Apply sampling rate
     if (Math.random() > this.config.sampleRate) return;
@@ -663,7 +669,7 @@ export class GameAnalytics {
 
       return {
         event: event.event,
-        distinct_id: event.userId || this.anonymousId || event.sessionId,
+        distinct_id: this.resolveDistinctId(event),
         timestamp: new Date(event.timestamp).toISOString(),
         properties,
       };
@@ -679,6 +685,34 @@ export class GameAnalytics {
       }),
       ...(keepalive ? { keepalive: true } : {}),
     };
+  }
+
+  private resolveDistinctId(event: AnalyticsEventData): string {
+    return event.userId || this.posthogDistinctId || this.anonymousId || event.sessionId;
+  }
+
+  private syncDistinctIdFromPostHog(): void {
+    getPostHog()
+      .then((posthog) => {
+        if (!posthog.__loaded) {
+          return;
+        }
+
+        const getDistinctId = (posthog as typeof posthog & { get_distinct_id?: () => unknown })
+          .get_distinct_id;
+        if (typeof getDistinctId !== "function") {
+          return;
+        }
+
+        const distinctId = getDistinctId();
+        if (typeof distinctId === "string" && distinctId.trim().length > 0) {
+          this.posthogDistinctId = distinctId;
+          this.anonymousId = distinctId;
+        }
+      })
+      .catch(() => {
+        // Best-effort sync; ignore SDK load failures in analytics path.
+      });
   }
 
   private requeueFailedEvents(events: AnalyticsEventData[]): void {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -153,7 +153,7 @@ export class GameAnalytics {
       window.addEventListener("beforeunload", () => this.flush({ keepalive: true }));
       window.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "hidden") {
-          this.flush();
+          this.flush({ keepalive: true });
         }
       });
     }
@@ -542,9 +542,9 @@ export class GameAnalytics {
       return;
     }
 
-    const events = [...this.eventQueue];
-    this.eventQueue = [];
-    const request = this.createFlushRequest(payloadFormat, events, options.keepalive === true);
+    const keepalive = options.keepalive === true;
+    const events = this.eventQueue.splice(0, this.getFlushBatchSize(keepalive));
+    const request = this.createFlushRequest(payloadFormat, events, keepalive);
     this.isFlushing = true;
 
     fetch(endpoint, request)
@@ -613,6 +613,16 @@ export class GameAnalytics {
       this.config.payloadFormat ??
       (this.shouldUsePostHogBatch(endpoint) ? "posthog-batch" : "events")
     );
+  }
+
+  private getFlushBatchSize(keepalive: boolean): number {
+    if (keepalive) {
+      // keepalive requests have strict body-size limits in browsers.
+      return 50;
+    }
+
+    const configuredBatchSize = Math.max(1, this.config.batchSize);
+    return Math.min(configuredBatchSize, 100);
   }
 
   /**

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -427,7 +427,7 @@ export class GameAnalytics {
 
     // Send to PostHog if available (lazy-loaded for bundle optimization)
     const shouldSkipDirectPostHogCapture =
-      !!this.config.endpoint && this.shouldUsePostHogBatch(this.config.endpoint);
+      !!this.config.endpoint && this.resolvePayloadFormat(this.config.endpoint) === "posthog-batch";
 
     if (typeof window !== "undefined" && !shouldSkipDirectPostHogCapture) {
       getPostHog().then((posthog) => {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -97,6 +97,7 @@ interface AnalyticsConfig {
   debugMode: boolean;
   sampleRate: number; // 0-1, for production sampling
   endpoint?: string; // Analytics endpoint URL
+  posthogKey?: string;
   batchSize: number;
   flushInterval: number; // ms
 }
@@ -115,6 +116,7 @@ export class GameAnalytics {
 
   private constructor(config?: Partial<AnalyticsConfig>) {
     const configuredEndpoint = process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT?.trim();
+    const configuredPosthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
 
     this.config = {
       enabled:
@@ -124,6 +126,7 @@ export class GameAnalytics {
       batchSize: 10,
       flushInterval: 5000, // 5 seconds
       endpoint: configuredEndpoint || undefined,
+      posthogKey: configuredPosthogKey || undefined,
       ...config,
     };
 
@@ -489,8 +492,14 @@ export class GameAnalytics {
     this.eventQueue = [];
 
     const endpoint = this.config.endpoint;
-    const request = this.createFlushRequest(events);
-    if (!endpoint || !request) {
+    if (!endpoint) {
+      return;
+    }
+
+    const request = this.createFlushRequest(endpoint, events);
+    if (!request) {
+      // Recover queue if payload generation fails (e.g. missing PostHog key).
+      this.eventQueue.unshift(...events);
       return;
     }
 
@@ -510,12 +519,8 @@ export class GameAnalytics {
   /**
    * Build flush request for configured endpoint
    */
-  private createFlushRequest(events: AnalyticsEventData[]): RequestInit | null {
-    if (!this.config.endpoint) {
-      return null;
-    }
-
-    if (this.config.endpoint.includes("/ingest")) {
+  private createFlushRequest(endpoint: string, events: AnalyticsEventData[]): RequestInit | null {
+    if (this.shouldUsePostHogBatch(endpoint)) {
       return this.createPostHogBatchRequest(events);
     }
 
@@ -528,10 +533,22 @@ export class GameAnalytics {
   }
 
   /**
+   * Use PostHog payload only for the known /ingest/batch endpoint.
+   */
+  private shouldUsePostHogBatch(endpoint: string): boolean {
+    try {
+      const pathname = new URL(endpoint, "https://analytics.local").pathname;
+      return pathname.replace(/\/+$/, "") === "/ingest/batch";
+    } catch {
+      return endpoint.replace(/\/+$/, "") === "/ingest/batch";
+    }
+  }
+
+  /**
    * Build PostHog batch payload for /ingest proxy endpoint
    */
   private createPostHogBatchRequest(events: AnalyticsEventData[]): RequestInit | null {
-    const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
+    const posthogKey = this.config.posthogKey;
     if (!posthogKey) {
       logger.error("Analytics endpoint uses PostHog proxy but NEXT_PUBLIC_POSTHOG_KEY is missing");
       return null;
@@ -539,8 +556,8 @@ export class GameAnalytics {
 
     const batch = events.map((event) => {
       const properties = this.cleanObject({
-        event_name: event.event,
         ...event.properties,
+        event_name: event.event,
         environment: event.environment,
         puzzle_number: event.puzzleNumber,
         session_id: event.sessionId,

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -116,6 +116,7 @@ export class GameAnalytics {
   private lastState: GameState | null = null;
   private stateHistory: StateTransition[] = [];
   private flushTimer?: NodeJS.Timeout;
+  private isFlushing = false;
   private hasLoggedInvalidPostHogConfig = false;
   private hasLoggedQueueOverflow = false;
 
@@ -523,6 +524,7 @@ export class GameAnalytics {
    */
   private flush(options: { keepalive?: boolean } = {}): void {
     if (this.eventQueue.length === 0) return;
+    if (this.isFlushing) return;
 
     const endpoint = this.config.endpoint;
     if (!endpoint) {
@@ -543,13 +545,26 @@ export class GameAnalytics {
     const events = [...this.eventQueue];
     this.eventQueue = [];
     const request = this.createFlushRequest(payloadFormat, events, options.keepalive === true);
+    this.isFlushing = true;
 
-    fetch(endpoint, request).catch((error) => {
-      logger.error("Analytics flush failed:", error);
-      // Re-add events to queue for retry
-      this.eventQueue.unshift(...events);
-      this.trimQueueIfNeeded();
-    });
+    fetch(endpoint, request)
+      .then((response) => {
+        // Retry transient upstream failures.
+        if (!response.ok && (response.status >= 500 || response.status === 429)) {
+          throw new Error(`Analytics flush failed with HTTP ${response.status}`);
+        }
+
+        if (!response.ok) {
+          logger.error("Analytics flush failed with non-retryable status:", response.status);
+        }
+      })
+      .catch((error) => {
+        logger.error("Analytics flush failed:", error);
+        this.requeueFailedEvents(events);
+      })
+      .finally(() => {
+        this.isFlushing = false;
+      });
 
     // Debug output
     if (this.config.debugMode) {
@@ -650,6 +665,12 @@ export class GameAnalytics {
     };
   }
 
+  private requeueFailedEvents(events: AnalyticsEventData[]): void {
+    // Preserve chronological order by restoring failed events ahead of newer queued events.
+    this.eventQueue = [...events, ...this.eventQueue];
+    this.trimQueueIfNeeded();
+  }
+
   /**
    * Keep queue bounded to prevent memory growth during outages.
    */
@@ -686,6 +707,7 @@ export class GameAnalytics {
     this.stateHistory = [];
     this.lastState = null;
     this.sessionId = this.generateSessionId();
+    this.isFlushing = false;
     this.hasLoggedInvalidPostHogConfig = false;
     this.hasLoggedQueueOverflow = false;
   }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -12,6 +12,10 @@
 import { logger } from "@/lib/logger";
 import { GameState, isReady } from "@/types/gameState";
 
+type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
+type JsonObject = { [key: string]: JsonValue | undefined };
+type JsonArray = JsonValue[];
+
 // Lazy-loaded PostHog - avoids bundling in initial chunk
 let posthogPromise: Promise<typeof import("posthog-js").default> | null = null;
 
@@ -110,6 +114,8 @@ export class GameAnalytics {
   private flushTimer?: NodeJS.Timeout;
 
   private constructor(config?: Partial<AnalyticsConfig>) {
+    const configuredEndpoint = process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT?.trim();
+
     this.config = {
       enabled:
         process.env.NODE_ENV === "production" || process.env.NEXT_PUBLIC_ANALYTICS_DEBUG === "true",
@@ -117,6 +123,7 @@ export class GameAnalytics {
       sampleRate: 1.0, // Track all events by default
       batchSize: 10,
       flushInterval: 5000, // 5 seconds
+      endpoint: configuredEndpoint || undefined,
       ...config,
     };
 
@@ -481,25 +488,94 @@ export class GameAnalytics {
     const events = [...this.eventQueue];
     this.eventQueue = [];
 
-    // In production, send to analytics endpoint
-    if (this.config.endpoint) {
-      fetch(this.config.endpoint, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ events }),
-        keepalive: true, // Important for beforeunload
-      }).catch((error) => {
-        logger.error("Analytics flush failed:", error);
-        // Re-add events to queue for retry
-        this.eventQueue.unshift(...events);
-      });
+    const endpoint = this.config.endpoint;
+    const request = this.createFlushRequest(events);
+    if (!endpoint || !request) {
+      return;
     }
+
+    fetch(endpoint, request).catch((error) => {
+      logger.error("Analytics flush failed:", error);
+      // Re-add events to queue for retry
+      this.eventQueue.unshift(...events);
+    });
 
     // Debug output
     if (this.config.debugMode) {
       // Using console.error which is allowed by ESLint
       logger.error("[Analytics] Flushed", events.length, "events");
     }
+  }
+
+  /**
+   * Build flush request for configured endpoint
+   */
+  private createFlushRequest(events: AnalyticsEventData[]): RequestInit | null {
+    if (!this.config.endpoint) {
+      return null;
+    }
+
+    if (this.config.endpoint.includes("/ingest")) {
+      return this.createPostHogBatchRequest(events);
+    }
+
+    return {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ events }),
+      keepalive: true, // Important for beforeunload
+    };
+  }
+
+  /**
+   * Build PostHog batch payload for /ingest proxy endpoint
+   */
+  private createPostHogBatchRequest(events: AnalyticsEventData[]): RequestInit | null {
+    const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
+    if (!posthogKey) {
+      logger.error("Analytics endpoint uses PostHog proxy but NEXT_PUBLIC_POSTHOG_KEY is missing");
+      return null;
+    }
+
+    const batch = events.map((event) => {
+      const properties = this.cleanObject({
+        event_name: event.event,
+        ...event.properties,
+        environment: event.environment,
+        puzzle_number: event.puzzleNumber,
+        session_id: event.sessionId,
+      });
+
+      return {
+        event: event.event,
+        distinct_id: event.userId || event.sessionId,
+        timestamp: new Date(event.timestamp).toISOString(),
+        properties,
+      };
+    });
+
+    return {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: posthogKey,
+        batch,
+        v: 1,
+      }),
+      keepalive: true, // Important for beforeunload
+    };
+  }
+
+  /**
+   * Remove undefined keys from object payloads
+   */
+  private cleanObject<T extends Record<string, JsonValue | undefined>>(
+    value: T,
+  ): Record<string, JsonValue> {
+    return Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined)) as Record<
+      string,
+      JsonValue
+    >;
   }
 
   /**

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -524,7 +524,10 @@ export class GameAnalytics {
    */
   private flush(options: { keepalive?: boolean } = {}): void {
     if (this.eventQueue.length === 0) return;
-    if (this.isFlushing) return;
+
+    const keepalive = options.keepalive === true;
+    const allowConcurrentKeepalive = keepalive && this.isFlushing;
+    if (this.isFlushing && !allowConcurrentKeepalive) return;
 
     const endpoint = this.config.endpoint;
     if (!endpoint) {
@@ -542,10 +545,11 @@ export class GameAnalytics {
       return;
     }
 
-    const keepalive = options.keepalive === true;
     const events = this.eventQueue.splice(0, this.getFlushBatchSize(keepalive));
     const request = this.createFlushRequest(payloadFormat, events, keepalive);
-    this.isFlushing = true;
+    if (!allowConcurrentKeepalive) {
+      this.isFlushing = true;
+    }
 
     fetch(endpoint, request)
       .then((response) => {
@@ -563,7 +567,9 @@ export class GameAnalytics {
         this.requeueFailedEvents(events);
       })
       .finally(() => {
-        this.isFlushing = false;
+        if (!allowConcurrentKeepalive) {
+          this.isFlushing = false;
+        }
       });
 
     // Debug output

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -99,6 +99,7 @@ interface AnalyticsConfig {
   endpoint?: string; // Analytics endpoint URL
   posthogKey?: string;
   batchSize: number;
+  maxQueueSize: number;
   flushInterval: number; // ms
 }
 
@@ -115,6 +116,7 @@ export class GameAnalytics {
   private stateHistory: StateTransition[] = [];
   private flushTimer?: NodeJS.Timeout;
   private hasLoggedInvalidPostHogConfig = false;
+  private hasLoggedQueueOverflow = false;
 
   private constructor(config?: Partial<AnalyticsConfig>) {
     const configuredEndpoint = process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT?.trim();
@@ -126,6 +128,7 @@ export class GameAnalytics {
       debugMode: process.env.NODE_ENV === "development",
       sampleRate: 1.0, // Track all events by default
       batchSize: 10,
+      maxQueueSize: 1000,
       flushInterval: 5000, // 5 seconds
       endpoint: configuredEndpoint || undefined,
       posthogKey: configuredPosthogKey || undefined,
@@ -143,7 +146,7 @@ export class GameAnalytics {
 
     // Bind window events for cleanup
     if (typeof window !== "undefined") {
-      window.addEventListener("beforeunload", () => this.flush());
+      window.addEventListener("beforeunload", () => this.flush({ keepalive: true }));
       window.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "hidden") {
           this.flush();
@@ -405,6 +408,7 @@ export class GameAnalytics {
 
     // Add to queue
     this.eventQueue.push(eventData);
+    this.trimQueueIfNeeded();
 
     // Debug logging
     if (this.config.debugMode) {
@@ -514,7 +518,7 @@ export class GameAnalytics {
   /**
    * Flush event queue to analytics service
    */
-  private flush(): void {
+  private flush(options: { keepalive?: boolean } = {}): void {
     if (this.eventQueue.length === 0) return;
 
     const events = [...this.eventQueue];
@@ -533,12 +537,13 @@ export class GameAnalytics {
       return;
     }
 
-    const request = this.createFlushRequest(endpoint, events);
+    const request = this.createFlushRequest(endpoint, events, options.keepalive === true);
 
     fetch(endpoint, request).catch((error) => {
       logger.error("Analytics flush failed:", error);
       // Re-add events to queue for retry
       this.eventQueue.unshift(...events);
+      this.trimQueueIfNeeded();
     });
 
     // Debug output
@@ -551,16 +556,20 @@ export class GameAnalytics {
   /**
    * Build flush request for configured endpoint
    */
-  private createFlushRequest(endpoint: string, events: AnalyticsEventData[]): RequestInit {
+  private createFlushRequest(
+    endpoint: string,
+    events: AnalyticsEventData[],
+    keepalive: boolean,
+  ): RequestInit {
     if (this.shouldUsePostHogBatch(endpoint)) {
-      return this.createPostHogBatchRequest(events);
+      return this.createPostHogBatchRequest(events, keepalive);
     }
 
     return {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ events }),
-      keepalive: true, // Important for beforeunload
+      ...(keepalive ? { keepalive: true } : {}),
     };
   }
 
@@ -579,7 +588,7 @@ export class GameAnalytics {
   /**
    * Build PostHog batch payload for /ingest proxy endpoint
    */
-  private createPostHogBatchRequest(events: AnalyticsEventData[]): RequestInit {
+  private createPostHogBatchRequest(events: AnalyticsEventData[], keepalive: boolean): RequestInit {
     const posthogKey = this.config.posthogKey;
     if (!posthogKey) {
       throw new Error("PostHog batch request requires NEXT_PUBLIC_POSTHOG_KEY");
@@ -610,8 +619,24 @@ export class GameAnalytics {
         batch,
         v: 1,
       }),
-      keepalive: true, // Important for beforeunload
+      ...(keepalive ? { keepalive: true } : {}),
     };
+  }
+
+  /**
+   * Keep queue bounded to prevent memory growth during outages.
+   */
+  private trimQueueIfNeeded(): void {
+    const overflow = this.eventQueue.length - this.config.maxQueueSize;
+    if (overflow <= 0) {
+      return;
+    }
+
+    this.eventQueue.splice(0, overflow);
+    if (!this.hasLoggedQueueOverflow) {
+      logger.error("Analytics queue capped; dropping oldest events to bound memory");
+      this.hasLoggedQueueOverflow = true;
+    }
   }
 
   /**
@@ -635,6 +660,7 @@ export class GameAnalytics {
     this.lastState = null;
     this.sessionId = this.generateSessionId();
     this.hasLoggedInvalidPostHogConfig = false;
+    this.hasLoggedQueueOverflow = false;
   }
 }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -509,11 +509,6 @@ export class GameAnalytics {
     }
 
     const request = this.createFlushRequest(endpoint, events);
-    if (!request) {
-      // Recover queue if payload generation fails (e.g. missing PostHog key).
-      this.eventQueue.unshift(...events);
-      return;
-    }
 
     fetch(endpoint, request).catch((error) => {
       logger.error("Analytics flush failed:", error);
@@ -531,7 +526,7 @@ export class GameAnalytics {
   /**
    * Build flush request for configured endpoint
    */
-  private createFlushRequest(endpoint: string, events: AnalyticsEventData[]): RequestInit | null {
+  private createFlushRequest(endpoint: string, events: AnalyticsEventData[]): RequestInit {
     if (this.shouldUsePostHogBatch(endpoint)) {
       return this.createPostHogBatchRequest(events);
     }
@@ -559,10 +554,10 @@ export class GameAnalytics {
   /**
    * Build PostHog batch payload for /ingest proxy endpoint
    */
-  private createPostHogBatchRequest(events: AnalyticsEventData[]): RequestInit | null {
+  private createPostHogBatchRequest(events: AnalyticsEventData[]): RequestInit {
     const posthogKey = this.config.posthogKey;
     if (!posthogKey) {
-      return null;
+      throw new Error("PostHog batch request requires NEXT_PUBLIC_POSTHOG_KEY");
     }
 
     const batch = events.map((event) => {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -113,6 +113,7 @@ export class GameAnalytics {
   private lastState: GameState | null = null;
   private stateHistory: StateTransition[] = [];
   private flushTimer?: NodeJS.Timeout;
+  private hasLoggedInvalidPostHogConfig = false;
 
   private constructor(config?: Partial<AnalyticsConfig>) {
     const configuredEndpoint = process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT?.trim();
@@ -415,7 +416,10 @@ export class GameAnalytics {
     }
 
     // Send to PostHog if available (lazy-loaded for bundle optimization)
-    if (typeof window !== "undefined") {
+    const shouldSkipDirectPostHogCapture =
+      !!this.config.endpoint && this.shouldUsePostHogBatch(this.config.endpoint);
+
+    if (typeof window !== "undefined" && !shouldSkipDirectPostHogCapture) {
       getPostHog().then((posthog) => {
         if (posthog.__loaded) {
           posthog.capture(event, {
@@ -496,6 +500,14 @@ export class GameAnalytics {
       return;
     }
 
+    if (this.shouldUsePostHogBatch(endpoint) && !this.config.posthogKey) {
+      if (!this.hasLoggedInvalidPostHogConfig) {
+        logger.error("Analytics endpoint is /ingest/batch but NEXT_PUBLIC_POSTHOG_KEY is missing");
+        this.hasLoggedInvalidPostHogConfig = true;
+      }
+      return;
+    }
+
     const request = this.createFlushRequest(endpoint, events);
     if (!request) {
       // Recover queue if payload generation fails (e.g. missing PostHog key).
@@ -550,7 +562,6 @@ export class GameAnalytics {
   private createPostHogBatchRequest(events: AnalyticsEventData[]): RequestInit | null {
     const posthogKey = this.config.posthogKey;
     if (!posthogKey) {
-      logger.error("Analytics endpoint uses PostHog proxy but NEXT_PUBLIC_POSTHOG_KEY is missing");
       return null;
     }
 
@@ -603,6 +614,7 @@ export class GameAnalytics {
     this.stateHistory = [];
     this.lastState = null;
     this.sessionId = this.generateSessionId();
+    this.hasLoggedInvalidPostHogConfig = false;
   }
 }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -97,6 +97,7 @@ interface AnalyticsConfig {
   debugMode: boolean;
   sampleRate: number; // 0-1, for production sampling
   endpoint?: string; // Analytics endpoint URL
+  payloadFormat?: "events" | "posthog-batch";
   posthogKey?: string;
   batchSize: number;
   maxQueueSize: number;
@@ -120,6 +121,7 @@ export class GameAnalytics {
 
   private constructor(config?: Partial<AnalyticsConfig>) {
     const configuredEndpoint = process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT?.trim();
+    const configuredPayloadFormat = process.env.NEXT_PUBLIC_ANALYTICS_FORMAT?.trim();
     const configuredPosthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
 
     this.config = {
@@ -131,6 +133,7 @@ export class GameAnalytics {
       maxQueueSize: 1000,
       flushInterval: 5000, // 5 seconds
       endpoint: configuredEndpoint || undefined,
+      payloadFormat: this.parsePayloadFormat(configuredPayloadFormat),
       posthogKey: configuredPosthogKey || undefined,
       ...config,
     };
@@ -521,23 +524,25 @@ export class GameAnalytics {
   private flush(options: { keepalive?: boolean } = {}): void {
     if (this.eventQueue.length === 0) return;
 
-    const events = [...this.eventQueue];
-    this.eventQueue = [];
-
     const endpoint = this.config.endpoint;
     if (!endpoint) {
       return;
     }
 
-    if (this.shouldUsePostHogBatch(endpoint) && !this.config.posthogKey) {
+    const payloadFormat = this.resolvePayloadFormat(endpoint);
+    if (payloadFormat === "posthog-batch" && !this.config.posthogKey) {
       if (!this.hasLoggedInvalidPostHogConfig) {
         logger.error("Analytics endpoint is /ingest/batch but NEXT_PUBLIC_POSTHOG_KEY is missing");
         this.hasLoggedInvalidPostHogConfig = true;
       }
+      // Configuration is invalid for this sink; drop buffered events to avoid a retry loop.
+      this.eventQueue = [];
       return;
     }
 
-    const request = this.createFlushRequest(endpoint, events, options.keepalive === true);
+    const events = [...this.eventQueue];
+    this.eventQueue = [];
+    const request = this.createFlushRequest(payloadFormat, events, options.keepalive === true);
 
     fetch(endpoint, request).catch((error) => {
       logger.error("Analytics flush failed:", error);
@@ -557,11 +562,11 @@ export class GameAnalytics {
    * Build flush request for configured endpoint
    */
   private createFlushRequest(
-    endpoint: string,
+    payloadFormat: "events" | "posthog-batch",
     events: AnalyticsEventData[],
     keepalive: boolean,
   ): RequestInit {
-    if (this.shouldUsePostHogBatch(endpoint)) {
+    if (payloadFormat === "posthog-batch") {
       return this.createPostHogBatchRequest(events, keepalive);
     }
 
@@ -571,6 +576,28 @@ export class GameAnalytics {
       body: JSON.stringify({ events }),
       ...(keepalive ? { keepalive: true } : {}),
     };
+  }
+
+  private parsePayloadFormat(value?: string): AnalyticsConfig["payloadFormat"] {
+    if (!value) {
+      return undefined;
+    }
+
+    if (value === "events" || value === "posthog-batch") {
+      return value;
+    }
+
+    logger.error(
+      "Invalid NEXT_PUBLIC_ANALYTICS_FORMAT. Expected 'events' or 'posthog-batch'. Falling back to endpoint-based inference.",
+    );
+    return undefined;
+  }
+
+  private resolvePayloadFormat(endpoint: string): "events" | "posthog-batch" {
+    return (
+      this.config.payloadFormat ??
+      (this.shouldUsePostHogBatch(endpoint) ? "posthog-batch" : "events")
+    );
   }
 
   /**

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -110,6 +110,7 @@ export class GameAnalytics {
   private config: AnalyticsConfig;
   private eventQueue: AnalyticsEventData[] = [];
   private sessionId: string;
+  private anonymousId?: string;
   private lastState: GameState | null = null;
   private stateHistory: StateTransition[] = [];
   private flushTimer?: NodeJS.Timeout;
@@ -133,6 +134,7 @@ export class GameAnalytics {
 
     // Generate session ID
     this.sessionId = this.generateSessionId();
+    this.anonymousId = this.getOrCreateAnonymousId();
 
     // Start flush timer if enabled
     if (this.config.enabled) {
@@ -472,6 +474,29 @@ export class GameAnalytics {
   }
 
   /**
+   * Get a stable anonymous ID for cross-refresh analytics deduplication.
+   */
+  private getOrCreateAnonymousId(): string | undefined {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const key = "chrondle-anonymous-id";
+    try {
+      const existing = window.localStorage.getItem(key);
+      if (existing) {
+        return existing;
+      }
+
+      const generated = `anon_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+      window.localStorage.setItem(key, generated);
+      return generated;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * Start flush timer
    */
   private startFlushTimer(): void {
@@ -571,7 +596,7 @@ export class GameAnalytics {
 
       return {
         event: event.event,
-        distinct_id: event.userId || event.sessionId,
+        distinct_id: event.userId || this.anonymousId || event.sessionId,
         timestamp: new Date(event.timestamp).toISOString(),
         properties,
       };


### PR DESCRIPTION
## Summary
- Read NEXT_PUBLIC_ANALYTICS_ENDPOINT in GameAnalytics constructor.
- Add flush request shaping:
  - /ingest => PostHog batch payload with api_key, batch, v:1.
  - other endpoints => raw { events } payload.
- Add env docs entry and observability verification checklist.
- Add unit tests covering both payload formats.
- Address review feedback to prevent endpoint misrouting, duplicate PostHog dispatch, and retry-loop behavior.

## Before / After
Before: Cerberus blocked the PR for broad endpoint routing, unresolved review threads, duplicate PostHog event dispatch, and retry-loop risk on missing PostHog key.
After: Endpoint detection is scoped to /ingest/batch, all review threads are replied/resolved, direct posthog.capture is skipped when batch sink is PostHog, and missing-key /ingest/batch no longer requeues indefinitely.

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New public analytics endpoint variable and selectable payload formats (PostHog batch or raw JSON), persistent anonymous IDs, queue size limits, periodic and on-unload flushing.

* **Documentation**
  * Game analytics verification guide, launch validation checklist, and expanded observability docs with client- and server-side examples.

* **Tests**
  * Extensive tests for batching, custom endpoints, anonymized IDs, queue behavior, failure/retry handling, and keepalive flushes.

* **Bug Fixes**
  * Prevent retry loops when PostHog key is missing; trim overflowed queues and handle keepalive correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Before / After (PR-Fix Pass 2)
Before: Council Verdict failed on new Cerberus findings (data-loss ordering in `flush` and endpoint-format abstraction concerns), leaving three unresolved review threads.
After: `flush` now checks endpoint before queue drain, explicit `NEXT_PUBLIC_ANALYTICS_FORMAT` routing was added with tests, all new threads were replied/resolved, and Council Verdict passed on commit `b9e7bb7`.

### Before / After (PR-Fix Pass 3)
Before: Three unresolved Cerberus review threads remained open around unload flush correctness and oversized flush payload risks.
After: Visibility-change flush now uses keepalive, flush sends bounded batches (100 regular / 50 keepalive), regression tests cover both behaviors, and all three open review threads were replied and resolved against commit `2d7a9c5`.

### Before / After (PR-Fix Pass 4)
Before: Two review threads remained unresolved after CI was green, including an unload-edge reliability concern in analytics flush locking.
After: Added concurrent keepalive flush path during in-flight regular flushes, covered with a regression test, replied to all open comments with commit-specific references, and resolved all remaining review threads.

### Before / After (PR-Fix Pass 5)
Before: One correctness thread remained open for PostHog identity mismatch between SDK events and batch payloads.
After: Batch payloads now sync `distinct_id` from PostHog SDK `get_distinct_id()` when loaded (with existing fallbacks), regression coverage added, comment thread replied with commit refs, and all review threads resolved.
