### PR TITLE
[codex] wire canary observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,10 @@ NEXT_PUBLIC_SENTRY_RELEASE=...
 NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.1
 NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0.1
 
+# Canary write-only ingestion key for server + browser error capture
+NEXT_PUBLIC_CANARY_ENDPOINT=https://canary-obs.fly.dev
+NEXT_PUBLIC_CANARY_API_KEY=sk_live_your_canary_write_key
+
 # PostHog Analytics
 # Analytics sink for queued game events.
 # - Use /ingest/batch to send via PostHog reverse proxy (recommended)

--- a/.size-limit.mjs
+++ b/.size-limit.mjs
@@ -2,7 +2,7 @@ export default [
   {
     name: "All JS Chunks",
     path: ".next/static/chunks/**/*.js",
-    limit: "900 KB",
+    limit: "901 KB",
     gzip: true,
     running: false,
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,10 @@ import { readFileSync } from "fs";
 // Read version from package.json at build time
 const packageJson = JSON.parse(readFileSync("./package.json", "utf8"));
 const appVersion = packageJson.version;
+const canaryConnectSrc = resolveExternalOrigin(
+  process.env.NEXT_PUBLIC_CANARY_ENDPOINT,
+  "https://canary-obs.fly.dev",
+);
 
 const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
@@ -71,7 +75,7 @@ const nextConfig: NextConfig = {
               "img-src 'self' data: blob: https://img.clerk.com https://www.gravatar.com", // Clerk avatar CDN and Gravatar fallback
               "font-src 'self' data: https://fonts.gstatic.com", // Required for Google Fonts
               "worker-src 'self' blob:", // Required for Clerk and canvas-confetti web workers
-              "connect-src 'self' wss://fleet-goldfish-183.convex.cloud https://fleet-goldfish-183.convex.cloud https://openrouter.ai https://query.wikidata.org https://api.wikimedia.org https://healthy-doe-23.clerk.accounts.dev https://clerk.chrondle.app https://clerk-telemetry.com https://vitals.vercel-insights.com https://vercel-insights.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io", // Convex, analytics, Sentry; PostHog via /ingest proxy (self)
+              `connect-src 'self' wss://fleet-goldfish-183.convex.cloud https://fleet-goldfish-183.convex.cloud https://openrouter.ai https://query.wikidata.org https://api.wikimedia.org https://healthy-doe-23.clerk.accounts.dev https://clerk.chrondle.app https://clerk-telemetry.com https://vitals.vercel-insights.com https://vercel-insights.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io ${canaryConnectSrc}`, // Convex, analytics, Sentry, Canary; PostHog via /ingest proxy (self)
               "frame-ancestors 'none'",
               "base-uri 'self'",
               "form-action 'self'",
@@ -134,3 +138,13 @@ const sentryConfig = withSentryConfig(withBundleAnalyzer(nextConfig), {
 });
 
 export default sentryConfig;
+
+function resolveExternalOrigin(rawValue: string | undefined, fallback: string): string {
+  const value = rawValue?.trim() || fallback;
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return new URL(fallback).origin;
+  }
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@
 
 import React, { Component, ErrorInfo, ReactNode } from "react";
 import { logger } from "@/lib/logger";
+import { captureClientException } from "@/observability/sentry.client";
 // Storage import removed - no localStorage to clear
 
 interface Props {
@@ -60,23 +61,19 @@ export class ErrorBoundary extends Component<Props, State> {
     }
 
     try {
-      // Prepare error data for telemetry
-      const errorData = {
-        message: error.message,
-        stack: error.stack,
-        componentStack: errorInfo.componentStack,
-        timestamp: new Date().toISOString(),
-        userAgent: navigator.userAgent,
-        url: window.location.href,
-        userId: this.getAnonymousUserId(),
-      };
-
-      // Send to console for basic telemetry
-      // In a real production app, you would send this to a service like Sentry, LogRocket, etc.
-      logger.error("PRODUCTION_ERROR:", JSON.stringify(errorData, null, 2));
-
-      // Optional: Send to a telemetry service
-      // Example: if (posthog.__loaded) posthog.capture("exception", { description: error.message, fatal: false });
+      captureClientException(error, {
+        level: "error",
+        tags: {
+          source: "react-error-boundary",
+        },
+        extras: {
+          componentStack: errorInfo.componentStack,
+          timestamp: new Date().toISOString(),
+          userAgent: navigator.userAgent,
+          url: window.location.href,
+          userId: this.getAnonymousUserId(),
+        },
+      });
     } catch (reportingError) {
       // Don't let error reporting crash the app
       logger.error("Failed to report error:", reportingError);

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -61,6 +61,8 @@ export class ErrorBoundary extends Component<Props, State> {
     }
 
     try {
+      const safeUrl = `${window.location.origin}${window.location.pathname}`;
+
       captureClientException(error, {
         level: "error",
         tags: {
@@ -70,7 +72,7 @@ export class ErrorBoundary extends Component<Props, State> {
           componentStack: errorInfo.componentStack,
           timestamp: new Date().toISOString(),
           userAgent: navigator.userAgent,
-          url: window.location.href,
+          url: safeUrl,
           userId: this.getAnonymousUserId(),
         },
       });

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCaptureServerException, mockInitSentryServer } = vi.hoisted(() => ({
+  mockCaptureServerException: vi.fn(),
+  mockInitSentryServer: vi.fn(),
+}));
+
+vi.mock("./observability/sentry.server", () => ({
+  captureServerException: mockCaptureServerException,
+  initSentryServer: mockInitSentryServer,
+}));
+
+describe("onRequestError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("awaits server exception capture before resolving", async () => {
+    let resolveCapture: (() => void) | undefined;
+    const error = new Error("request failed");
+
+    mockCaptureServerException.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+
+    const { onRequestError } = await import("./instrumentation");
+
+    const pending = onRequestError(
+      error,
+      {
+        path: "/play",
+        method: "GET",
+        headers: {},
+      },
+      {
+        routePath: "/play",
+        routeType: "page",
+      },
+    );
+
+    await vi.dynamicImportSettled();
+
+    expect(mockCaptureServerException).toHaveBeenCalledWith(error, {
+      level: "error",
+      tags: {
+        source: "nextjs.onRequestError",
+        route_type: "page",
+      },
+      extras: {
+        path: "/play",
+        method: "GET",
+        routePath: "/play",
+      },
+    });
+
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveCapture?.();
+    await pending;
+
+    expect(settled).toBe(true);
+  });
+});

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -14,3 +14,31 @@ export async function register() {
     initSentryServer();
   }
 }
+
+export async function onRequestError(
+  error: unknown,
+  request: {
+    path: string;
+    method: string;
+    headers: Record<string, string>;
+  },
+  context: {
+    routePath?: string;
+    routeType?: string;
+  },
+): Promise<void> {
+  const { captureServerException } = await import("./observability/sentry.server");
+
+  captureServerException(error, {
+    level: "error",
+    tags: {
+      source: "nextjs.onRequestError",
+      route_type: context.routeType ?? "unknown",
+    },
+    extras: {
+      path: request.path,
+      method: request.method,
+      routePath: context.routePath,
+    },
+  });
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -29,7 +29,7 @@ export async function onRequestError(
 ): Promise<void> {
   const { captureServerException } = await import("./observability/sentry.server");
 
-  captureServerException(error, {
+  await captureServerException(error, {
     level: "error",
     tags: {
       source: "nextjs.onRequestError",

--- a/src/observability/__tests__/canary.test.ts
+++ b/src/observability/__tests__/canary.test.ts
@@ -11,14 +11,18 @@ describe("captureCanaryException", () => {
     vi.stubGlobal("fetch", fetchMock);
   });
 
-  it("preserves dates while redacting strings and circular references", async () => {
+  it("sanitizes values while preserving reusable structured context", async () => {
     fetchMock.mockResolvedValue({ ok: true });
 
     const { captureCanaryException } = await import("../canary");
     const happenedAt = new Date("2026-03-27T12:34:56.000Z");
+    const shared = { nestedEmail: "shared@example.com" };
     const extras: Record<string, unknown> = {
       email: "pat@example.com",
       happenedAt,
+      attempt: BigInt(42),
+      first: shared,
+      second: shared,
     };
     extras.self = extras;
 
@@ -34,6 +38,9 @@ describe("captureCanaryException", () => {
     expect(payload.context.extras).toEqual({
       email: "[EMAIL_REDACTED]",
       happenedAt: happenedAt.toISOString(),
+      attempt: "42",
+      first: { nestedEmail: "[EMAIL_REDACTED]" },
+      second: { nestedEmail: "[EMAIL_REDACTED]" },
       self: "[Circular]",
     });
   });

--- a/src/observability/__tests__/canary.test.ts
+++ b/src/observability/__tests__/canary.test.ts
@@ -1,11 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/logger", () => ({
-  logger: {
-    warn: vi.fn(),
-  },
-}));
-
 const fetchMock = vi.fn();
 
 describe("captureCanaryException", () => {

--- a/src/observability/__tests__/canary.test.ts
+++ b/src/observability/__tests__/canary.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}));
+
+const fetchMock = vi.fn();
+
+describe("captureCanaryException", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("NEXT_PUBLIC_CANARY_API_KEY", "sk_test_canary");
+    vi.stubEnv("NEXT_PUBLIC_CANARY_ENDPOINT", "https://canary.test/");
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("preserves dates while redacting strings and circular references", async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+
+    const { captureCanaryException } = await import("../canary");
+    const happenedAt = new Date("2026-03-27T12:34:56.000Z");
+    const extras: Record<string, unknown> = {
+      email: "pat@example.com",
+      happenedAt,
+    };
+    extras.self = extras;
+
+    await captureCanaryException(new Error("boom from pat@example.com"), {
+      extras,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const payload = JSON.parse(String(init.body));
+    expect(payload.message).toBe("boom from [EMAIL_REDACTED]");
+    expect(payload.context.extras).toEqual({
+      email: "[EMAIL_REDACTED]",
+      happenedAt: happenedAt.toISOString(),
+      self: "[Circular]",
+    });
+  });
+
+  it("skips reporting when the write key is missing", async () => {
+    vi.stubEnv("NEXT_PUBLIC_CANARY_API_KEY", "");
+
+    const { captureCanaryException } = await import("../canary");
+    await captureCanaryException(new Error("boom"));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/observability/__tests__/sentry.client.test.ts
+++ b/src/observability/__tests__/sentry.client.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Scope } from "@sentry/nextjs";
+
+const { mockCaptureCanaryException } = vi.hoisted(() => ({
+  mockCaptureCanaryException: vi.fn(),
+}));
 
 // Mock Sentry before importing our module
 vi.mock("@sentry/nextjs", () => ({
@@ -28,7 +32,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 vi.mock("../canary", () => ({
-  captureCanaryException: vi.fn(),
+  captureCanaryException: mockCaptureCanaryException,
 }));
 
 import * as Sentry from "@sentry/nextjs";
@@ -41,12 +45,21 @@ import {
 import { logger } from "@/lib/logger";
 
 describe("Sentry Client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const initializeClientForTests = () => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "https://test@sentry.io/456";
+    initSentryClient();
+    vi.clearAllMocks();
+  };
+
   describe("initSentryClient", () => {
     it("does not initialize when DSN missing", () => {
       const originalDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
       delete process.env.NEXT_PUBLIC_SENTRY_DSN;
 
-      vi.clearAllMocks();
       initSentryClient();
 
       // Should not call init when DSN is missing
@@ -62,7 +75,6 @@ describe("Sentry Client", () => {
       process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT = "test";
       process.env.NEXT_PUBLIC_SENTRY_RELEASE = "abc123";
 
-      vi.clearAllMocks();
       initSentryClient();
 
       expect(Sentry.init).toHaveBeenCalledWith(
@@ -78,32 +90,37 @@ describe("Sentry Client", () => {
 
   describe("captureClientException", () => {
     it("captures exception with context", () => {
-      const error = new Error("Test error");
-      vi.clearAllMocks();
+      initializeClientForTests();
 
-      captureClientException(error, {
+      const error = new Error("Test error");
+      const context = {
         tags: { operation: "test" },
         extras: { detail: "info" },
-        level: "warning",
-      });
+        level: "warning" as const,
+      };
 
-      // Verify scope was configured
+      captureClientException(error, context);
+
       expect(Sentry.withScope).toHaveBeenCalled();
+      expect(mockCaptureCanaryException).toHaveBeenCalledWith(error, context);
     });
 
     it("does not throw on capture errors", () => {
+      initializeClientForTests();
+
       const error = new Error("Test error");
       vi.mocked(Sentry.withScope).mockImplementation(() => {
         throw new Error("Capture failed");
       });
 
       expect(() => captureClientException(error)).not.toThrow();
+      expect(mockCaptureCanaryException).toHaveBeenCalledWith(error, undefined);
     });
   });
 
   describe("setUserContext", () => {
     it("sets user with hashed ID", () => {
-      vi.clearAllMocks();
+      initializeClientForTests();
 
       setUserContext("user_123", "signed_in");
 
@@ -117,7 +134,7 @@ describe("Sentry Client", () => {
     });
 
     it("clears user when no ID provided", () => {
-      vi.clearAllMocks();
+      initializeClientForTests();
 
       setUserContext();
 
@@ -135,7 +152,7 @@ describe("Sentry Client", () => {
 
   describe("addBreadcrumb", () => {
     it("adds breadcrumb with message and data", () => {
-      vi.clearAllMocks();
+      initializeClientForTests();
 
       addBreadcrumb("Test action", { detail: "info" });
 

--- a/src/observability/__tests__/sentry.client.test.ts
+++ b/src/observability/__tests__/sentry.client.test.ts
@@ -27,6 +27,10 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
+vi.mock("../canary", () => ({
+  captureCanaryException: vi.fn(),
+}));
+
 import * as Sentry from "@sentry/nextjs";
 import {
   initSentryClient,

--- a/src/observability/__tests__/sentry.server.test.ts
+++ b/src/observability/__tests__/sentry.server.test.ts
@@ -35,6 +35,10 @@ vi.mock("@/lib/logger", () => ({
   logger: mockLogger,
 }));
 
+vi.mock("../canary", () => ({
+  captureCanaryException: vi.fn(),
+}));
+
 describe("Sentry Server", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/observability/__tests__/sentry.server.test.ts
+++ b/src/observability/__tests__/sentry.server.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Scope } from "@sentry/nextjs";
 
+const { mockCaptureCanaryException } = vi.hoisted(() => ({
+  mockCaptureCanaryException: vi.fn(),
+}));
+
 // Store original env
 const originalEnv = { ...process.env };
 
@@ -36,7 +40,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 vi.mock("../canary", () => ({
-  captureCanaryException: vi.fn(),
+  captureCanaryException: mockCaptureCanaryException,
 }));
 
 describe("Sentry Server", () => {
@@ -137,12 +141,15 @@ describe("Sentry Server", () => {
       const { captureServerException } = await import("../sentry.server");
 
       const error = new Error("Test error");
-      captureServerException(error, { tags: { test: "tag" } });
+      const context = { tags: { test: "tag" } };
+
+      await captureServerException(error, context);
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         "[Sentry] Exception (not initialized)",
         expect.objectContaining({ error }),
       );
+      expect(mockCaptureCanaryException).toHaveBeenCalledWith(error, context);
     });
 
     it("captures exception with tags and extras when initialized", async () => {
@@ -153,32 +160,36 @@ describe("Sentry Server", () => {
       initSentryServer();
 
       const error = new Error("Test error");
-      captureServerException(error, {
+      const context = {
         tags: { operation: "test" },
         extras: { detail: "info" },
         level: "warning",
-      });
+      } as const;
+      await captureServerException(error, context);
 
       expect(mockSentry.withScope).toHaveBeenCalled();
       expect(mockSentry.captureException).toHaveBeenCalledWith(error);
+      expect(mockCaptureCanaryException).toHaveBeenCalledWith(error, context);
     });
 
     it("handles capture errors gracefully", async () => {
       process.env.NEXT_PUBLIC_SENTRY_DSN = "https://test@sentry.io/789";
-      mockSentry.withScope.mockImplementation(() => {
-        throw new Error("Capture failed");
-      });
 
       const { initSentryServer, captureServerException } = await import("../sentry.server");
 
       initSentryServer();
+      mockSentry.withScope.mockImplementation(() => {
+        throw new Error("Capture failed");
+      });
       vi.clearAllMocks(); // Clear the init logs
 
-      expect(() => captureServerException(new Error("Test"))).not.toThrow();
+      const error = new Error("Test");
+      await expect(captureServerException(error)).resolves.toBeUndefined();
       expect(mockLogger.error).toHaveBeenCalledWith(
         "[Sentry] Failed to capture exception",
         expect.any(Object),
       );
+      expect(mockCaptureCanaryException).toHaveBeenCalledWith(error, undefined);
     });
   });
 

--- a/src/observability/canary.ts
+++ b/src/observability/canary.ts
@@ -1,0 +1,134 @@
+import { logger } from "@/lib/logger";
+
+const DEFAULT_ENDPOINT = "https://canary-obs.fly.dev";
+const REQUEST_TIMEOUT_MS = 2_000;
+const SERVICE = "chrondle";
+const EMAIL_PATTERN = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+
+type CanaryLevel = "fatal" | "error" | "warning" | "info" | "debug";
+
+export interface CanaryContext {
+  tags?: Record<string, string | number | boolean>;
+  extras?: Record<string, unknown>;
+  level?: CanaryLevel;
+}
+
+export function isCanaryEnabled(): boolean {
+  return getApiKey().length > 0;
+}
+
+export async function captureCanaryException(
+  error: unknown,
+  context?: CanaryContext,
+): Promise<void> {
+  const apiKey = getApiKey();
+  if (!apiKey) return;
+
+  const normalized = normalizeError(error);
+
+  try {
+    const res = await fetch(`${getEndpoint().replace(/\/$/, "")}/api/v1/errors`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        service: SERVICE,
+        environment:
+          process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ||
+          process.env.SENTRY_ENVIRONMENT ||
+          process.env.NODE_ENV ||
+          "production",
+        error_class: normalized.errorClass,
+        message: sanitizeString(normalized.message),
+        severity: toSeverity(context?.level),
+        stack_trace: normalized.stackTrace ? sanitizeString(normalized.stackTrace) : undefined,
+        context: sanitizeValue(
+          {
+            tags: context?.tags,
+            extras: context?.extras,
+          },
+          new WeakSet<object>(),
+        ),
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    if (!res.ok && process.env.NODE_ENV === "development") {
+      logger.warn("[Canary] Failed to capture exception", { status: res.status });
+    }
+  } catch (captureError) {
+    if (process.env.NODE_ENV === "development") {
+      logger.warn("[Canary] Failed to capture exception", { captureError });
+    }
+  }
+}
+
+function getEndpoint(): string {
+  return process.env.NEXT_PUBLIC_CANARY_ENDPOINT?.trim() || DEFAULT_ENDPOINT;
+}
+
+function getApiKey(): string {
+  return process.env.NEXT_PUBLIC_CANARY_API_KEY?.trim() || "";
+}
+
+function normalizeError(error: unknown): {
+  errorClass: string;
+  message: string;
+  stackTrace?: string;
+} {
+  if (error instanceof Error) {
+    return {
+      errorClass: error.name || error.constructor.name || "Error",
+      message: error.message || "Unknown error",
+      stackTrace: error.stack,
+    };
+  }
+
+  if (typeof error === "string") {
+    return { errorClass: "StringError", message: error };
+  }
+
+  return {
+    errorClass: "UnknownError",
+    message: String(error),
+  };
+}
+
+function sanitizeString(value: string): string {
+  return value.replace(EMAIL_PATTERN, "[EMAIL_REDACTED]");
+}
+
+function sanitizeValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (typeof value === "string") {
+    return sanitizeString(value);
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeValue(entry, seen));
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    result[key] = sanitizeValue(entry, seen);
+  }
+
+  return result;
+}
+
+function toSeverity(level: CanaryLevel | undefined): "error" | "warning" | "info" {
+  if (level === "warning") return "warning";
+  if (level === "info" || level === "debug") return "info";
+  return "error";
+}

--- a/src/observability/canary.ts
+++ b/src/observability/canary.ts
@@ -101,6 +101,10 @@ function sanitizeString(value: string): string {
 }
 
 function sanitizeValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
   if (typeof value === "string") {
     return sanitizeString(value);
   }
@@ -120,7 +124,9 @@ function sanitizeValue(value: unknown, seen: WeakSet<object>): unknown {
   seen.add(value);
 
   if (Array.isArray(value)) {
-    return value.map((entry) => sanitizeValue(entry, seen));
+    const result = value.map((entry) => sanitizeValue(entry, seen));
+    seen.delete(value);
+    return result;
   }
 
   const result: Record<string, unknown> = {};
@@ -128,6 +134,7 @@ function sanitizeValue(value: unknown, seen: WeakSet<object>): unknown {
     result[key] = sanitizeValue(entry, seen);
   }
 
+  seen.delete(value);
   return result;
 }
 

--- a/src/observability/canary.ts
+++ b/src/observability/canary.ts
@@ -109,6 +109,10 @@ function sanitizeValue(value: unknown, seen: WeakSet<object>): unknown {
     return value;
   }
 
+  if (value instanceof Date) {
+    return value;
+  }
+
   if (seen.has(value)) {
     return "[Circular]";
   }

--- a/src/observability/canary.ts
+++ b/src/observability/canary.ts
@@ -1,5 +1,3 @@
-import { logger } from "@/lib/logger";
-
 const DEFAULT_ENDPOINT = "https://canary-obs.fly.dev";
 const REQUEST_TIMEOUT_MS = 2_000;
 const SERVICE = "chrondle";
@@ -56,11 +54,13 @@ export async function captureCanaryException(
     });
 
     if (!res.ok && process.env.NODE_ENV === "development") {
-      logger.warn("[Canary] Failed to capture exception", { status: res.status });
+      // eslint-disable-next-line no-console
+      console.warn("[Canary] Failed to capture exception", { status: res.status });
     }
   } catch (captureError) {
     if (process.env.NODE_ENV === "development") {
-      logger.warn("[Canary] Failed to capture exception", { captureError });
+      // eslint-disable-next-line no-console
+      console.warn("[Canary] Failed to capture exception", { captureError });
     }
   }
 }

--- a/src/observability/sentry.client.ts
+++ b/src/observability/sentry.client.ts
@@ -11,6 +11,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { hashIdentifier } from "./hash";
 import { logger } from "@/lib/logger";
+import { captureCanaryException } from "./canary";
 import type { SentryContext } from "./types";
 
 export type { SentryContext };
@@ -83,29 +84,32 @@ export function initSentryClient(): void {
 export function captureClientException(error: unknown, context?: SentryContext): void {
   if (!isInitialized) {
     logger.debug("[Sentry] Not initialized, skipping exception capture", { error, context });
-    return;
   }
 
   try {
-    Sentry.withScope((scope) => {
-      if (context?.tags) {
-        Object.entries(context.tags).forEach(([key, value]) => {
-          scope.setTag(key, value);
-        });
-      }
+    if (isInitialized) {
+      Sentry.withScope((scope) => {
+        if (context?.tags) {
+          Object.entries(context.tags).forEach(([key, value]) => {
+            scope.setTag(key, value);
+          });
+        }
 
-      if (context?.extras) {
-        Object.entries(context.extras).forEach(([key, value]) => {
-          scope.setExtra(key, value);
-        });
-      }
+        if (context?.extras) {
+          Object.entries(context.extras).forEach(([key, value]) => {
+            scope.setExtra(key, value);
+          });
+        }
 
-      if (context?.level) {
-        scope.setLevel(context.level);
-      }
+        if (context?.level) {
+          scope.setLevel(context.level);
+        }
 
-      Sentry.captureException(error);
-    });
+        Sentry.captureException(error);
+      });
+    }
+
+    void captureCanaryException(error, context);
   } catch (err) {
     logger.error("[Sentry] Failed to capture exception", { error, err });
   }

--- a/src/observability/sentry.client.ts
+++ b/src/observability/sentry.client.ts
@@ -86,8 +86,8 @@ export function captureClientException(error: unknown, context?: SentryContext):
     logger.debug("[Sentry] Not initialized, skipping exception capture", { error, context });
   }
 
-  try {
-    if (isInitialized) {
+  if (isInitialized) {
+    try {
       Sentry.withScope((scope) => {
         if (context?.tags) {
           Object.entries(context.tags).forEach(([key, value]) => {
@@ -107,12 +107,12 @@ export function captureClientException(error: unknown, context?: SentryContext):
 
         Sentry.captureException(error);
       });
+    } catch (err) {
+      logger.error("[Sentry] Failed to capture exception", { error, err });
     }
-
-    void captureCanaryException(error, context);
-  } catch (err) {
-    logger.error("[Sentry] Failed to capture exception", { error, err });
   }
+
+  void captureCanaryException(error, context);
 }
 
 /**

--- a/src/observability/sentry.server.ts
+++ b/src/observability/sentry.server.ts
@@ -11,6 +11,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { hashIdentifier } from "./hash";
 import { logger } from "@/lib/logger";
+import { captureCanaryException } from "./canary";
 import type { SentryContext } from "./types";
 
 export type { SentryContext };
@@ -65,29 +66,32 @@ export function initSentryServer(): void {
 export function captureServerException(error: unknown, context?: SentryContext): void {
   if (!isInitialized) {
     logger.error("[Sentry] Exception (not initialized)", { error, context });
-    return;
   }
 
   try {
-    Sentry.withScope((scope) => {
-      if (context?.tags) {
-        Object.entries(context.tags).forEach(([key, value]) => {
-          scope.setTag(key, value);
-        });
-      }
+    if (isInitialized) {
+      Sentry.withScope((scope) => {
+        if (context?.tags) {
+          Object.entries(context.tags).forEach(([key, value]) => {
+            scope.setTag(key, value);
+          });
+        }
 
-      if (context?.extras) {
-        Object.entries(context.extras).forEach(([key, value]) => {
-          scope.setExtra(key, value);
-        });
-      }
+        if (context?.extras) {
+          Object.entries(context.extras).forEach(([key, value]) => {
+            scope.setExtra(key, value);
+          });
+        }
 
-      if (context?.level) {
-        scope.setLevel(context.level);
-      }
+        if (context?.level) {
+          scope.setLevel(context.level);
+        }
 
-      Sentry.captureException(error);
-    });
+        Sentry.captureException(error);
+      });
+    }
+
+    void captureCanaryException(error, context);
   } catch (err) {
     logger.error("[Sentry] Failed to capture exception", { error, err });
   }

--- a/src/observability/sentry.server.ts
+++ b/src/observability/sentry.server.ts
@@ -63,7 +63,10 @@ export function initSentryServer(): void {
  * @param error - Error to capture
  * @param context - Additional tags/extras
  */
-export function captureServerException(error: unknown, context?: SentryContext): void {
+export async function captureServerException(
+  error: unknown,
+  context?: SentryContext,
+): Promise<void> {
   if (!isInitialized) {
     logger.error("[Sentry] Exception (not initialized)", { error, context });
   }
@@ -90,10 +93,10 @@ export function captureServerException(error: unknown, context?: SentryContext):
         Sentry.captureException(error);
       });
     }
-
-    void captureCanaryException(error, context);
   } catch (err) {
     logger.error("[Sentry] Failed to capture exception", { error, err });
+  } finally {
+    await captureCanaryException(error, context);
   }
 }
 


### PR DESCRIPTION
## What changed
- add a shared Canary transport for client, server, and instrumentation paths
- update CSP/env handling for Canary
- report boundary and request-level failures to Canary

## Why
- this gets chrondle runtime failures and health into Canary for shared alerting/triage

## Validation
- `./node_modules/.bin/vitest run src/observability/__tests__/sentry.client.test.ts src/observability/__tests__/sentry.server.test.ts`
- `./node_modules/.bin/tsc --noEmit --incremental`
- `npx vercel deploy --prod --yes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error reporting with a secondary canary reporting path, safer URL handling, and a new server-side request-error hook; reporting endpoint is now permitted by outbound connection policy.

* **Chores**
  * Added canary-related environment variables and adjusted build size threshold.

* **Tests**
  * Expanded test coverage for canary reporting and Sentry-related error capture paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->