### PR TITLE
Add file-backed backlog and migrate vetted GitHub issues

### DIFF
--- a/.backlog.d/001-strengthen-daily-habit-loop.md
+++ b/.backlog.d/001-strengthen-daily-habit-loop.md
@@ -1,0 +1,25 @@
+# Strengthen the daily habit loop
+
+Priority: high
+Status: ready
+Estimate: M
+
+## Goal
+Make the default player path start today's puzzle immediately and give solvers an explicit next-day return hook once they finish.
+
+## Non-Goals
+- Rework scoring, hint semantics, or puzzle-integrity rules
+- Redesign every game mode surface in one pass
+- Add retention mechanics that leak answer-era information
+
+## Oracle
+- [ ] [behavioral] Visiting `/` presents a primary path into today's daily puzzle without requiring a mode-selection detour first.
+- [ ] [behavioral] Completing a puzzle surfaces an explicit return or reminder CTA, using the existing notification capability where appropriate, instead of only passive countdown/share affordances.
+- [ ] [test] Add or extend coverage for the home entry path and the completion-state return CTA.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Origin: local grooming synthesis retained during the GitHub-issue migration. No current open GitHub issue captures this end-to-end habit-loop gap cleanly.
+- Evidence: the first-touch experience starts in [GamesGallery.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/GamesGallery.tsx) as a mode chooser instead of a direct play path; the main shell remains busy in [AppHeader.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/AppHeader.tsx); the current completion flow is passive in [GameComplete.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/modals/GameComplete.tsx); settings currently foreground billing only in [page.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/app/(app)/settings/page.tsx).
+- Touchpoints: `src/components/GamesGallery.tsx`, `src/components/AppHeader.tsx`, `src/components/modals/GameComplete.tsx`, `src/app/(app)/settings/page.tsx`, notification/reminder UI if already present.
+- Constraint: preserve the Prime Directive from `CLAUDE.md`; no UI changes may hint at the answer or auto-infer the era.

--- a/.backlog.d/002-simplify-classic-range-entry.md
+++ b/.backlog.d/002-simplify-classic-range-entry.md
@@ -1,0 +1,26 @@
+# Simplify classic range entry
+
+Priority: high
+Status: ready
+Estimate: M
+
+## Goal
+Reduce the control burden of submitting a classic-mode range so most players can narrow and commit a guess through one clear primary interaction path, with focus returning somewhere useful after submission.
+
+## Non-Goals
+- Change scoring math, attempt limits, or hint unlock rules
+- Remove text entry entirely if it still serves as a useful fallback
+- Add era inference, smart validation, or any other answer-leaking behavior
+
+## Oracle
+- [ ] [behavioral] A player can set and submit a valid range through one primary control path without having to manually edit both year fields for the common case.
+- [ ] [behavioral] Era handling remains fully player-driven; the UI does not infer or suggest BC/AD based on the hidden answer.
+- [ ] [behavioral] After a submission, keyboard focus moves to the next useful continuation point instead of leaving the player stranded in the cleared input surface.
+- [ ] [test] Add or extend behavioral coverage for the simplified range-entry flow, validation edges, and puzzle-integrity guardrails.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#121`
+- Evidence: the current flow in [RangeInput.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/game/RangeInput.tsx) requires coordinating two inputs and two era toggles before submission; related presentation and feedback live in [GameLayout.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/GameLayout.tsx), [HintIndicator.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/game/HintIndicator.tsx), and adjacent range controls.
+- Touchpoints: `src/components/game/RangeInput.tsx`, `src/components/game/RangeSlider.tsx`, `src/components/game/RangePreview.tsx`, `src/components/GameLayout.tsx`, `src/components/ui/EraToggle.tsx`.
+- Constraint: optimize for speed and legibility, not feature count. If text entry stays, it should support the primary interaction rather than define it.

--- a/.backlog.d/003-rebuild-archive-data-path.md
+++ b/.backlog.d/003-rebuild-archive-data-path.md
@@ -1,0 +1,27 @@
+# Rebuild archive data path
+
+Priority: high
+Status: ready
+Estimate: L
+
+## Goal
+Delete the stubbed `src/lib/puzzleData.ts` compatibility path and move archive/count consumers onto live Convex data with indexed pagination so archive state cannot silently drift behind fake defaults or degrade as puzzle volume grows.
+
+## Non-Goals
+- Redesign archive monetization, pagination, or visual layout
+- Sweep unrelated gameplay-state refactors into the same diff
+- Change Convex schema unless the live query surface truly requires it
+
+## Oracle
+- [ ] [behavioral] Archive/count surfaces render from live Convex-backed values rather than zero-count or always-valid compatibility defaults.
+- [ ] [behavioral] Classic and Order archive queries avoid full-table scans and manual in-memory pagination on the hot page-load path.
+- [ ] [command] `rg "from \"@/lib/puzzleData\"|fetchTotalPuzzles|TOTAL_PUZZLES|validatePuzzleData" src convex` returns no live production references outside tests or archived notes.
+- [ ] [command] `rg "collect\\(|slice\\(" convex/puzzles/queries.ts convex/orderPuzzles/queries.ts` shows no archive pagination path that still performs full scans and manual page slicing.
+- [ ] [test] Add or extend regression coverage for the affected archive/count consumer path.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#105`
+- Evidence: [puzzleData.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/lib/puzzleData.ts) still exposes `total_puzzles = 0`, `TOTAL_PUZZLES = 0`, and `validatePuzzleData()` returning `true`; [ClassicArchivePuzzleClient.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/classic/ClassicArchivePuzzleClient.tsx) still consumes `fetchTotalPuzzles()`; archive queries in [queries.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/convex/puzzles/queries.ts) and [queries.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/convex/orderPuzzles/queries.ts) still use `collect()` plus `slice()` on the archive path.
+- Touchpoints: `src/lib/puzzleData.ts`, `src/components/classic/ClassicArchivePuzzleClient.tsx`, `convex/puzzles/queries.ts`, `convex/orderPuzzles/queries.ts`, and nearby archive tests.
+- Follow-up candidate, not part of this item: inert diagnostics around `useRangeGame()` and `manualGeneratePuzzle()` should either emit useful signals or be deleted in a later pass.

--- a/.backlog.d/004-polish-recovery-and-motion-accessibility.md
+++ b/.backlog.d/004-polish-recovery-and-motion-accessibility.md
@@ -1,0 +1,24 @@
+# Polish recovery and motion accessibility
+
+Priority: high
+Status: ready
+Estimate: S
+
+## Goal
+Make failure recovery and celebratory motion safe and accessible by fixing invalid interaction semantics and honoring reduced-motion preferences.
+
+## Non-Goals
+- Redesign the full error-boundary experience
+- Replace the celebration visual system wholesale
+- Bundle unrelated visual cleanup into the same diff
+
+## Oracle
+- [ ] [behavioral] `GameErrorBoundary` exposes its “Go to Today’s Puzzle” action without nesting a button inside a link.
+- [ ] [behavioral] Celebration effects disable or simplify themselves when the user prefers reduced motion.
+- [ ] [test] Add or extend coverage for the error-boundary navigation markup and reduced-motion celebration behavior.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#208`, `#155`
+- Evidence: [GameErrorBoundary.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/GameErrorBoundary.tsx) still nests a button inside a link; [Celebration.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/ui/Celebration.tsx) still animates without a reduced-motion gate.
+- Touchpoints: `src/components/GameErrorBoundary.tsx`, `src/components/ui/Celebration.tsx`, related tests.

--- a/.backlog.d/005-improve-order-mode-affordance-and-a11y.md
+++ b/.backlog.d/005-improve-order-mode-affordance-and-a11y.md
@@ -1,0 +1,24 @@
+# Improve Order mode affordance and accessibility
+
+Priority: high
+Status: ready
+Estimate: M
+
+## Goal
+Make Order mode immediately understandable to new players and properly described to assistive technologies.
+
+## Non-Goals
+- Redesign Order scoring or puzzle generation
+- Replace drag-and-drop with a different interaction model
+- Bundle dead-code cleanup into the same item
+
+## Oracle
+- [ ] [behavioral] The drag affordance clearly communicates where and how to drag on first use.
+- [ ] [behavioral] The drag handle has an accessible label and any helper affordance does not interfere with keyboard reordering.
+- [ ] [test] Add or extend coverage for the drag-handle accessibility contract and the first-use affordance behavior.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#98`, `#114`
+- Evidence: [DraggableEventCard.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/order/DraggableEventCard.tsx) still renders a handle without an ARIA label, and open issue `#98` captures ongoing first-use confusion around the drag model.
+- Touchpoints: `src/components/order/DraggableEventCard.tsx`, `src/components/order/OrderGameBoard.tsx`, Order-mode helper UI, related tests.

--- a/.backlog.d/006-retire-dead-gameplay-compatibility-surfaces.md
+++ b/.backlog.d/006-retire-dead-gameplay-compatibility-surfaces.md
@@ -1,0 +1,24 @@
+# Retire dead gameplay compatibility surfaces
+
+Priority: high
+Status: ready
+Estimate: L
+
+## Goal
+Reduce hidden coupling in gameplay state by decomposing the god-hook session path and deleting dead compatibility code that invites the wrong execution paths.
+
+## Non-Goals
+- Change live scoring rules for either game mode
+- Redesign authenticated versus anonymous product behavior
+- Sweep archive-query work into this item
+
+## Oracle
+- [ ] [behavioral] Session management responsibilities are split so authenticated and anonymous persistence paths no longer live in one branching god hook.
+- [ ] [command] `rg "calculateOrderScore|OrderScore|@deprecated Use AttemptScore|saveProgress\\(|loadProgress\\(|saveSettings\\(|loadSettings\\(" src convex` returns no live production compatibility surface that should have been deleted.
+- [ ] [test] Add or update coverage around the new session boundaries and any dead-code removals that affect imports.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#112`, `#120`, `#123`, `#106`
+- Evidence: [useLocalSession.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/hooks/data/useLocalSession.ts) still carries both authenticated and anonymous branching; open issues `#120` and `#123` identify stale Order scoring/types; [gameState.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/lib/gameState.ts) still contains legacy storage helpers.
+- Touchpoints: `src/hooks/data/useLocalSession.ts`, `src/lib/gameState.ts`, `src/lib/order/`, `src/types/orderGameState.ts`, related tests.

--- a/.backlog.d/007-unify-puzzle-date-semantics-and-docs.md
+++ b/.backlog.d/007-unify-puzzle-date-semantics-and-docs.md
@@ -1,0 +1,24 @@
+# Unify puzzle date semantics and docs
+
+Priority: high
+Status: ready
+Estimate: M
+
+## Goal
+Choose one explicit daily-puzzle date model across classic mode, Order mode, countdown behavior, and project documentation, then make the implementation and docs agree.
+
+## Non-Goals
+- Change historical scoring or archive visibility policy
+- Introduce answer-leaking timing hints
+- Bundle unrelated cron infrastructure cleanup into the same diff
+
+## Oracle
+- [ ] [behavioral] Classic and Order daily puzzle retrieval follow the same documented date semantics.
+- [ ] [behavioral] Countdown text and rollover behavior match the chosen semantics.
+- [ ] [test] Add or update coverage for the chosen date boundary behavior.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#99`
+- Evidence: code comments in [GameIsland.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/GameIsland.tsx) and hooks under `src/hooks/useTodaysPuzzle.ts` describe local-date behavior, while repo docs still describe Central Time or UTC-centric scheduling in multiple places.
+- Touchpoints: `src/hooks/useTodaysPuzzle.ts`, `src/hooks/useTodaysOrderPuzzle.ts`, `src/hooks/useCountdown.ts`, `convex/puzzles/queries.ts`, `convex/orderPuzzles/queries.ts`, `README.md`, `CLAUDE.md`.

--- a/.backlog.d/008-harden-account-and-access-boundaries.md
+++ b/.backlog.d/008-harden-account-and-access-boundaries.md
@@ -1,0 +1,26 @@
+# Harden account and access boundaries
+
+Priority: high
+Status: ready
+Estimate: L
+
+## Goal
+Close the remaining account, play-read, webhook, and streak-merge trust gaps so access decisions and user data flow only through authenticated server-owned boundaries.
+
+## Non-Goals
+- Rebuild the entire auth stack
+- Change subscription product behavior beyond what is needed for safety and correctness
+- Fold Order submission contract work into this item
+
+## Oracle
+- [ ] [behavioral] Classic and Order play-read APIs no longer accept arbitrary `userId` values to read another user’s progress.
+- [ ] [behavioral] The Clerk webhook fails closed when `CLERK_WEBHOOK_SECRET` is missing instead of attempting verification with an empty string.
+- [ ] [behavioral] Anonymous streak merge is idempotent or replay-resistant enough that repeated identical merge attempts cannot inflate streaks.
+- [ ] [test] Add coverage for `trialEndsAt` precedence in archive access and the hardened read/merge/webhook boundaries.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#93`, `#94`, `#95`, `#162`
+- Evidence: [plays/queries.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/convex/plays/queries.ts) and [queries.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/convex/orderPlays/queries.ts) still accept `userId` arguments directly; [route.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/app/(app)/api/webhooks/clerk/route.ts) still warns and proceeds when `CLERK_WEBHOOK_SECRET` is absent; [anonymous.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/convex/migration/anonymous.ts) still merges anonymous streaks without replay tracking.
+- Already fixed and should stay fixed: issue `#91` style auth derivation in classic submit mutations and issue `#92` style internalized webhook user creation.
+- Touchpoints: `convex/plays/queries.ts`, `convex/orderPlays/queries.ts`, `convex/migration/anonymous.ts`, `src/app/(app)/api/webhooks/clerk/route.ts`, `convex/users/helpers.ts`, related tests.

--- a/.backlog.d/009-tighten-convex-app-contracts-and-order-persistence.md
+++ b/.backlog.d/009-tighten-convex-app-contracts-and-order-persistence.md
@@ -1,0 +1,26 @@
+# Tighten Convex app contracts and Order persistence
+
+Priority: high
+Status: ready
+Estimate: L
+
+## Goal
+Make the Order-mode client/server boundary mechanically enforced through shared contracts, persistence tests, and CI checks, while removing direct Convex-to-`src/` coupling.
+
+## Non-Goals
+- Rewrite the full Order gameplay surface
+- Replace Convex with another backend
+- Expand this item into unrelated analytics or archive work
+
+## Oracle
+- [ ] [behavioral] Order submission payloads are typed from the authoritative Convex validator surface or a shared contract that cannot silently drift.
+- [ ] [behavioral] Reloading an authenticated Order completion after submit preserves the completed state end-to-end.
+- [ ] [command] `rg "import .*src/" convex` returns no remaining Convex-to-`src/` boundary violations.
+- [ ] [test] Add or update unit, integration, and E2E coverage for exact payload shape and authenticated persistence.
+- [ ] [command] CI fails when Convex generated files or declared contract checks drift from committed state.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#100`, `#101`, `#102`, `#103`, `#107`
+- Evidence: [useOrderGame.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/hooks/useOrderGame.ts) still sends a client `userId` field into `submitOrderPlay`; issue `#103` remains only partially satisfied by existing generated-file verification; issue `#107` captures the broader Convex-to-app domain leakage.
+- Touchpoints: `src/hooks/useOrderGame.ts`, `convex/orderPuzzles/mutations.ts`, Order-mode tests under `src/hooks/` and `convex/orderPuzzles/`, CI workflow and Convex verification scripts.

--- a/.backlog.d/010-harden-and-simplify-analytics-pipeline.md
+++ b/.backlog.d/010-harden-and-simplify-analytics-pipeline.md
@@ -1,0 +1,26 @@
+# Harden and simplify analytics pipeline
+
+Priority: medium
+Status: ready
+Estimate: M
+
+## Goal
+Keep analytics collection reliable without making the core game module own provider-specific logic, retry storms, or a two-step provider bootstrap waterfall.
+
+## Non-Goals
+- Change the chosen analytics vendor
+- Redesign every event name or dashboard
+- Move unrelated observability work into this diff
+
+## Oracle
+- [ ] [behavioral] Provider-specific payload formatting no longer lives inside the core `GameAnalytics` orchestration path.
+- [ ] [behavioral] Failed analytics flushes back off and cap queue growth instead of retrying aggressively.
+- [ ] [behavioral] PostHog provider initialization uses one coherent async bootstrap path rather than a two-stage waterfall.
+- [ ] [test] Add or update coverage for provider selection, queue cap/backoff, and provider bootstrap behavior.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#198`, `#197`, `#195`
+- Evidence: [analytics.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/lib/analytics.ts) still mixes provider payload behavior into core logic; [PostHogProvider.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/providers/PostHogProvider.tsx) still performs a staged bootstrap.
+- Precursor already shipped: closed issue `#132` established the analytics endpoint and `/ingest` path, so this item is about hardening and simplification rather than initial setup.
+- Touchpoints: `src/lib/analytics.ts`, `src/components/providers/PostHogProvider.tsx`, analytics tests.

--- a/.backlog.d/011-complete-semantic-design-token-sweep.md
+++ b/.backlog.d/011-complete-semantic-design-token-sweep.md
@@ -1,0 +1,24 @@
+# Complete semantic design token sweep
+
+Priority: medium
+Status: ready
+Estimate: M
+
+## Goal
+Finish the move from raw hex values and primitive Tailwind status colors to semantic design tokens across the product surface.
+
+## Non-Goals
+- Redesign the visual identity from scratch
+- Bundle icon-adapter or font-loading work into this item
+- Rewrite stable components just to chase style preferences
+
+## Oracle
+- [ ] [behavioral] Success and error states use semantic tokens rather than `text-green-*`, `text-red-*`, or raw hex shortcuts.
+- [ ] [command] `rg "text-green-|text-red-|#[0-9a-fA-F]{3,6}" src/app src/components src/styles` returns only intentional token definitions or approved asset data.
+- [ ] [test] Update any tests that still assert raw color values.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#207`, `#170`
+- Evidence: open token-sweep issues still reference remaining raw color usage, and [EraToggle.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/ui/EraToggle.tsx) still shows direct color literals.
+- Touchpoints: `src/app/globals.css`, affected components across `src/components/`, and related UI tests.

--- a/.backlog.d/012-centralize-frontend-platform-config-and-vendor-boundaries.md
+++ b/.backlog.d/012-centralize-frontend-platform-config-and-vendor-boundaries.md
@@ -1,0 +1,25 @@
+# Centralize frontend platform config and vendor boundaries
+
+Priority: medium
+Status: ready
+Estimate: M
+
+## Goal
+Hide frontend platform choices behind local config and adapter modules so metadata, font loading, and icon-vendor changes stop amplifying across the tree.
+
+## Non-Goals
+- Redesign brand identity or icon choices
+- Replace the current icon set again in the same diff
+- Pull design-token cleanup into this item
+
+## Oracle
+- [ ] [behavioral] Site metadata is sourced from one local config module rather than being redefined inline across layout metadata.
+- [ ] [behavioral] Fonts load via `next/font/google` rather than raw `<link>` tags in the root layout.
+- [ ] [command] `rg "@phosphor-icons/react" src/app src/components` returns only approved adapter-module imports, not direct vendor usage throughout the app surface.
+- [ ] [test] Add or update coverage only where these changes alter observable output or imports.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#209`, `#136`, `#166`
+- Evidence: [layout.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/app/layout.tsx) still uses raw Google Fonts links; [layout.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/app/(app)/layout.tsx) still defines metadata inline; icon imports are still spread directly across app/component files.
+- Touchpoints: `src/app/layout.tsx`, `src/app/(app)/layout.tsx`, local config module(s), icon adapter module(s), affected imports.

--- a/.backlog.d/013-make-leakage-learning-useful-or-remove-it.md
+++ b/.backlog.d/013-make-leakage-learning-useful-or-remove-it.md
@@ -1,0 +1,23 @@
+# Make leakage learning useful or remove it
+
+Priority: medium
+Status: ready
+Estimate: M
+
+## Goal
+Ensure learned semantic-leakage phrases add real signal to puzzle quality checks, or remove the learning path so low-value phrases do not accumulate.
+
+## Non-Goals
+- Rebuild the entire event-generation stack
+- Add heavyweight NLP just to satisfy a heuristic
+- Fold historical-context rendering work into this item
+
+## Oracle
+- [ ] [behavioral] Learned phrases contribute meaningful recall or precision by design, rather than storing long event-text fragments that rarely match.
+- [ ] [test] Add or update coverage showing how learned phrases are extracted, pruned, or intentionally disabled.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#186`
+- Evidence: [qualityValidator.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/convex/lib/qualityValidator.ts) still learns by truncating and storing full event text via `learnFromRejected()`.
+- Touchpoints: `convex/lib/qualityValidator.ts`, `convex/data/leakyPhrases.json`, quality-validator tests.

--- a/.backlog.d/014-refresh-social-share-surface.md
+++ b/.backlog.d/014-refresh-social-share-surface.md
@@ -1,0 +1,23 @@
+# Refresh social share surface
+
+Priority: low
+Status: ready
+Estimate: S
+
+## Goal
+Make the social preview and share image feel crisp, legible, and intentionally branded instead of oversized or muddy.
+
+## Non-Goals
+- Rebuild the whole marketing site
+- Change the metadata plumbing that already exists
+- Fold Product Hunt kit maintenance into the same diff unless directly needed for the share surface
+
+## Oracle
+- [ ] [behavioral] The OG/share image reads cleanly at common social-preview sizes and reflects the product’s current visual language.
+- [ ] [behavioral] The updated share asset is wired through the existing metadata surface without regressions.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#191`
+- Evidence: issue `#191` remains an open qualitative complaint about the current share image even though the metadata plumbing is already in place.
+- Touchpoints: `public/og-image.png` or generator source, `src/app/(app)/layout.tsx`, any supporting asset-generation scripts.

--- a/.backlog.d/015-codify-engineering-guardrails-and-debt-tracking.md
+++ b/.backlog.d/015-codify-engineering-guardrails-and-debt-tracking.md
@@ -1,0 +1,24 @@
+# Codify engineering guardrails and debt tracking
+
+Priority: low
+Status: ready
+Estimate: S
+
+## Goal
+Turn security-hotfix scope isolation and TODO/debt visibility into repo-enforced conventions instead of one-off reminders.
+
+## Non-Goals
+- Rebuild the entire contributing guide
+- Auto-close GitHub issues from code comments in the first pass
+- Replace the new `.backlog.d` system with another tracker
+
+## Oracle
+- [ ] [behavioral] Security hotfix scope-isolation guidance is captured in a durable repo artifact such as a PR template, playbook, or checklist.
+- [ ] [behavioral] Code TODOs are triaged into an explicit convention or enforcement rule instead of accumulating as free-form comments.
+- [ ] [command] `rg "TODO" src convex scripts` no longer returns untracked debt comments that violate the chosen convention.
+- [ ] [command] `bun run lint && bun run type-check && bun run test`
+
+## Notes
+- Related GitHub issues: `#200`, `#124`
+- Evidence: issue `#200` captures scope-creep risk in security fixes, and issue `#124` captures the repo’s scattered TODO debt.
+- Touchpoints: contributing docs, PR template/checklists, TODO policy enforcement, `.backlog.d` maintenance conventions.

--- a/.backlog.d/_done/000-restore-local-backlog-mirror.md
+++ b/.backlog.d/_done/000-restore-local-backlog-mirror.md
@@ -1,0 +1,22 @@
+# Restore local backlog mirror
+
+Priority: medium
+Status: done
+Estimate: S
+
+## Goal
+Reintroduce a repo-local backlog surface so grooming output, active priorities, and execution order are visible in the workspace even if GitHub issues remain canonical.
+
+## Non-Goals
+- Mirror every GitHub issue into the repository
+- Automate issue sync in the first pass
+- Replace GitHub as the long-term system of record unless the team chooses that later
+
+## Oracle
+- [x] `backlog.d/` exists in the repo and contains the active priorities from the current grooming session.
+- [x] Each active backlog item includes `Goal`, `Non-Goals`, and `Oracle` sections.
+- [x] A completed item exists under `backlog.d/_done/` to preserve the fact that the local mirror was restored during this session.
+
+## Notes
+- Evidence: this workspace had no `backlog.d/`, `project.md`, or `BACKLOG.md` when the grooming session started.
+- Reason for completion now: creating `backlog.d/` and the prioritized items in this session satisfies the lightweight local-mirror recommendation immediately.

--- a/.backlog.d/_done/001-audit-open-github-issues-and-migrate-them.md
+++ b/.backlog.d/_done/001-audit-open-github-issues-and-migrate-them.md
@@ -18,6 +18,8 @@ Triage every currently open GitHub issue into an active `.backlog.d` item or a v
 - [x] `.backlog.d` is the local source of truth and `backlog.d` remains available as a compatibility symlink.
 
 ## Notes
+- Scope: this migration covers the live open issue set only. Closed issues remain in GitHub as historical record rather than being bulk-imported into `_done/`.
+- Open issue count at migration time: 35
 - Active mappings:
 - `002-simplify-classic-range-entry.md`: `#121`
 - `003-rebuild-archive-data-path.md`: `#105`

--- a/.backlog.d/_done/001-audit-open-github-issues-and-migrate-them.md
+++ b/.backlog.d/_done/001-audit-open-github-issues-and-migrate-them.md
@@ -1,0 +1,41 @@
+# Audit open GitHub issues and migrate them into .backlog.d
+
+Priority: high
+Status: done
+Estimate: M
+
+## Goal
+Triage every currently open GitHub issue into an active `.backlog.d` item or a vetted non-active disposition so local planning can replace issue sprawl.
+
+## Non-Goals
+- Mirror every historical closed issue into the repo
+- Close GitHub issues automatically from the workspace
+- Preserve one-file-per-issue granularity when several issues share the same deep module or outcome
+
+## Oracle
+- [x] Every currently open GitHub issue in `misty-step/chrondle` is accounted for in an active backlog item or a vetted non-active disposition.
+- [x] Active backlog item count is under the 30-item grooming cap.
+- [x] `.backlog.d` is the local source of truth and `backlog.d` remains available as a compatibility symlink.
+
+## Notes
+- Active mappings:
+- `002-simplify-classic-range-entry.md`: `#121`
+- `003-rebuild-archive-data-path.md`: `#105`
+- `004-polish-recovery-and-motion-accessibility.md`: `#208`, `#155`
+- `005-improve-order-mode-affordance-and-a11y.md`: `#98`, `#114`
+- `006-retire-dead-gameplay-compatibility-surfaces.md`: `#112`, `#120`, `#123`, `#106`
+- `007-unify-puzzle-date-semantics-and-docs.md`: `#99`
+- `008-harden-account-and-access-boundaries.md`: `#93`, `#94`, `#95`, `#162`
+- `009-tighten-convex-app-contracts-and-order-persistence.md`: `#100`, `#101`, `#102`, `#103`, `#107`
+- `010-harden-and-simplify-analytics-pipeline.md`: `#198`, `#197`, `#195`
+- `011-complete-semantic-design-token-sweep.md`: `#207`, `#170`
+- `012-centralize-frontend-platform-config-and-vendor-boundaries.md`: `#209`, `#136`, `#166`
+- `013-make-leakage-learning-useful-or-remove-it.md`: `#186`
+- `014-refresh-social-share-surface.md`: `#191`
+- `015-codify-engineering-guardrails-and-debt-tracking.md`: `#200`, `#124`
+- Existing local backlog retained: `001-strengthen-daily-habit-loop.md` remains active from prior grooming even though it is not sourced from a current open GitHub issue.
+- Resolved or superseded on inspection:
+- `#108` resolved by the live health endpoint in [route.ts](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/app/(app)/api/health/route.ts).
+- `#165` superseded by current dynamic puzzle labels in [GamesGallery.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/GamesGallery.tsx), even though the implementation differs from the issue’s original SSR suggestion.
+- Not migrated after vetting:
+- `#122` was dropped as a speculative memoization request without evidence of a live regression and with weak fit for the repo’s current React guidance.

--- a/backlog.d
+++ b/backlog.d
@@ -1,0 +1,1 @@
+.backlog.d


### PR DESCRIPTION
## Summary
- add a new `.backlog.d/` file-backed backlog with 15 active items and 2 completed audit records
- migrate and consolidate vetted GitHub issues into scoped backlog items with goals, non-goals, and oracles
- document the GitHub issue migration outcome, including resolved, superseded, and dropped items

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a local backlog with 15 new prioritized planning items and 2 completed entries to improve project planning and task visibility (includes accessibility, analytics, archive/data, onboarding/affordance, date semantics, account/access, and social/share work items).
  * Added an empty tracked backlog marker file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->