### PR TITLE
fix: harden envless builds and stabilize dagger ci

### DIFF
--- a/.evidence/fix-ci-workflow-polish/2026-04-14/review-synthesis.md
+++ b/.evidence/fix-ci-workflow-polish/2026-04-14/review-synthesis.md
@@ -1,0 +1,34 @@
+# Review Synthesis
+
+Date: 2026-04-14
+Branch: `fix/ci-workflow-polish`
+Base: `master`
+Verdict: `ship`
+
+## Scope
+
+- Harden env-less and partially deployed builds so Classic, Order, and Groups degrade safely instead of crashing.
+- Stabilize Dagger type-checking in ephemeral CI by using a non-incremental TypeScript entrypoint.
+- Remove shallow unavailable-state indirection and add regression coverage for the new failure paths.
+
+## Findings
+
+- No blocking correctness, security, or release-readiness issues remain in the final diff.
+
+## Important Checks
+
+- `Providers` now reads required public env at render time and rejects blank values.
+- Order and Groups pages only swallow known backend-unavailable preload failures; unexpected errors still surface.
+- Admin dashboard is explicitly dynamic, which prevents build-time Clerk evaluation failures.
+- Dagger quality now runs `type-check:ci`, avoiding incremental compiler state in ephemeral containers.
+- Regression tests cover missing env, blank env, render-time env changes, bounded preload fallbacks, and the admin dynamic export.
+
+## Residual Risks
+
+- Backend-unavailable preload detection still relies on known error-message patterns. The matcher is now bounded, but upstream message changes could require maintenance.
+- The Convex client cache in `providers.tsx` is module-global state keyed by URL. That is acceptable for the current browser bootstrap path, but it should stay narrowly scoped.
+
+## Verification
+
+- Local checks passed before settlement closeout: `bun run type-check`, `bun run lint`, `bun run build`, `bun run test`
+- Full Dagger `check` passed with explicit public bootstrap env values.

--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,2 +1,3 @@
 {"date":"2026-04-08","pr":null,"correctness":8,"depth":8,"simplicity":7,"craft":8,"verdict":"ship","providers":["codex","beck","carmack","ousterhout"]}
 {"date":"2026-04-14","pr":null,"correctness":9,"depth":8,"simplicity":9,"craft":9,"verdict":"ship","providers":["codex"]}
+{"date":"2026-04-14","pr":null,"correctness":9,"depth":9,"simplicity":9,"craft":9,"verdict":"ship","providers":["codex","internal-bench"]}

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -139,7 +139,9 @@ export class Ci {
     if (check === "lint") {
       container = container.withExec(["bun", "run", "lint"]);
     } else {
-      container = container.withExec(["bun", "run", "type-check"]);
+      // Dagger runs in ephemeral containers, so incremental TypeScript state adds
+      // memory pressure without saving any work. Use the non-incremental CI entrypoint.
+      container = container.withExec(["bun", "run", "type-check:ci"]);
     }
 
     return container;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
     "type-check": "tsc --noEmit --incremental",
+    "type-check:ci": "tsc --noEmit --incremental false",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",

--- a/src/app/(app)/admin/dashboard/page.test.ts
+++ b/src/app/(app)/admin/dashboard/page.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@clerk/nextjs/server", () => ({
+  currentUser: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
+
+vi.mock("@/components/AppHeader", () => ({
+  AppHeader: () => null,
+}));
+
+vi.mock("@/components/Footer", () => ({
+  Footer: () => null,
+}));
+
+vi.mock("@/app/(app)/admin/dashboard/components/AdminTabs", () => ({
+  AdminTabs: () => null,
+}));
+
+import { dynamic } from "@/app/(app)/admin/dashboard/page";
+
+describe("AdminDashboardPage module", () => {
+  it("forces dynamic rendering to avoid build-time Clerk evaluation", () => {
+    expect(dynamic).toBe("force-dynamic");
+  });
+});

--- a/src/app/(app)/admin/dashboard/page.tsx
+++ b/src/app/(app)/admin/dashboard/page.tsx
@@ -5,6 +5,10 @@ import { AppHeader } from "@/components/AppHeader";
 import { Footer } from "@/components/Footer";
 import { AdminTabs } from "./components/AdminTabs";
 
+// Authenticated admin pages must render per-request. Static prerendering
+// evaluates Clerk during build and fails when local secrets are absent.
+export const dynamic = "force-dynamic";
+
 /**
  * Admin Dashboard - Event Generation Command Center
  *

--- a/src/app/(app)/archive/groups/[puzzleNumber]/page.tsx
+++ b/src/app/(app)/archive/groups/[puzzleNumber]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { ArchiveErrorBoundary } from "@/components/ArchiveErrorBoundary";
+import { ModeUnavailableState } from "@/components/ModeUnavailableState";
 import { ArchiveGroupsPuzzleClient } from "@/components/groups/ArchiveGroupsPuzzleClient";
-import { GroupsUnavailableState } from "@/components/groups/GroupsUnavailableState";
 import { logger } from "@/lib/logger";
 import { fetchGroupsPuzzleByNumber, getConvexClient } from "@/lib/convexServer";
 
@@ -35,7 +35,7 @@ export default async function ArchiveGroupsPuzzlePage(props: ArchiveGroupsPuzzle
     return (
       <ArchiveErrorBoundary>
         <div className="bg-background flex min-h-screen items-center px-4 py-8">
-          <GroupsUnavailableState
+          <ModeUnavailableState
             title="This Groups Puzzle Is Unavailable"
             description="The archive detail query is not available on this backend yet. Try the homepage or the classic archive while the Convex deploy catches up."
             primaryHref="/"

--- a/src/app/(app)/archive/groups/page.tsx
+++ b/src/app/(app)/archive/groups/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@phosphor-icons/react/dist/ssr";
 import { ArchiveErrorBoundary } from "@/components/ArchiveErrorBoundary";
 import { ArchiveGrid } from "@/components/archive/ArchiveGrid";
-import { GroupsUnavailableState } from "@/components/groups/GroupsUnavailableState";
+import { ModeUnavailableState } from "@/components/ModeUnavailableState";
 import { UserCreationHandler } from "@/components/UserCreationHandler";
 import { LoadingShell } from "@/components/LoadingShell";
 import { logger } from "@/lib/logger";
@@ -214,7 +214,7 @@ async function GroupsArchivePageContent({
           )}
 
           {archiveUnavailable ? (
-            <GroupsUnavailableState
+            <ModeUnavailableState
               title="Groups Archive Is Unavailable"
               description="This environment is missing the Groups archive queries. Try again after the Convex deploy finishes, or jump back to the live daily modes."
               primaryHref="/"

--- a/src/app/(app)/groups/page.test.tsx
+++ b/src/app/(app)/groups/page.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const { preloadQueryMock, warnMock } = vi.hoisted(() => ({
+  preloadQueryMock: vi.fn(),
+  warnMock: vi.fn(),
+}));
+
+vi.mock("convex/nextjs", () => ({
+  preloadQuery: preloadQueryMock,
+}));
+
+vi.mock("@/lib/convexServer", () => ({
+  api: {
+    groupsPuzzles: {
+      getDailyGroupsPuzzle: "groups-query",
+    },
+  },
+}));
+
+vi.mock("@/components/groups/GroupsGameIsland", () => ({
+  GroupsGameIsland: ({ preloadedPuzzle }: { preloadedPuzzle: unknown }) => (
+    <div data-testid="groups-game-island">{preloadedPuzzle ? "loaded" : "missing"}</div>
+  ),
+}));
+
+vi.mock("@/components/LoadingShell", () => ({
+  LoadingShell: () => <div data-testid="loading-shell">loading</div>,
+}));
+
+vi.mock("@/components/GameModeUnavailableState", () => ({
+  GameModeUnavailableState: ({ title }: { title: string }) => (
+    <div data-testid="mode-unavailable-state">{title}</div>
+  ),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: warnMock,
+  },
+}));
+
+import GroupsPage from "@/app/(app)/groups/page";
+
+describe("GroupsPage", () => {
+  beforeEach(() => {
+    preloadQueryMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it("renders the groups island when preload succeeds", async () => {
+    preloadQueryMock.mockResolvedValueOnce({ preloaded: true });
+
+    render(await GroupsPage());
+
+    expect(screen.getByTestId("groups-game-island")).toHaveTextContent("loaded");
+    expect(screen.queryByTestId("mode-unavailable-state")).not.toBeInTheDocument();
+  });
+
+  it("renders the unavailable state when preload returns null", async () => {
+    preloadQueryMock.mockResolvedValueOnce(null);
+
+    render(await GroupsPage());
+
+    expect(screen.getByTestId("mode-unavailable-state")).toHaveTextContent("Groups Is Unavailable");
+    expect(warnMock).toHaveBeenCalledWith(
+      "[GroupsPage] Daily Groups puzzle unavailable during preload",
+    );
+  });
+
+  it("renders the unavailable state for known backend-unavailable errors", async () => {
+    preloadQueryMock.mockRejectedValueOnce(
+      new Error("Environment variable NEXT_PUBLIC_CONVEX_URL is not set."),
+    );
+
+    render(await GroupsPage());
+
+    expect(screen.getByTestId("mode-unavailable-state")).toHaveTextContent("Groups Is Unavailable");
+    expect(warnMock).toHaveBeenCalledWith("[GroupsPage] Failed to preload Groups puzzle", {
+      error: expect.any(Error),
+    });
+  });
+
+  it("rethrows unexpected preload failures", async () => {
+    preloadQueryMock.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(GroupsPage()).rejects.toThrow("boom");
+  });
+});

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -1,38 +1,48 @@
 import React, { Suspense } from "react";
 import { preloadQuery } from "convex/nextjs";
+import { GameModeUnavailableState } from "@/components/GameModeUnavailableState";
 import { GroupsGameIsland } from "@/components/groups/GroupsGameIsland";
-import { GroupsUnavailableState } from "@/components/groups/GroupsUnavailableState";
-import { GameModeLayout } from "@/components/GameModeLayout";
 import { LoadingShell } from "@/components/LoadingShell";
 import { api } from "@/lib/convexServer";
 import { logger } from "@/lib/logger";
+import { isBackendUnavailablePreloadError } from "@/lib/preloadQueryAvailability";
 
 export default async function GroupsPage() {
   let preloadedPuzzle = null;
-  let backendUnavailable = false;
 
   try {
     preloadedPuzzle = await preloadQuery(api.groupsPuzzles.getDailyGroupsPuzzle);
   } catch (error) {
-    backendUnavailable = true;
+    if (!isBackendUnavailablePreloadError(error)) {
+      throw error;
+    }
+
     logger.warn("[GroupsPage] Failed to preload Groups puzzle", { error });
+    return (
+      <GameModeUnavailableState
+        mode="groups"
+        title="Groups Is Unavailable"
+        description="This build cannot load the daily Groups puzzle yet because the backend configuration or deployment is incomplete. Classic and Order remain available while Groups catches up."
+        primaryHref="/"
+        primaryLabel="Back to Home"
+        secondaryHref="/classic"
+        secondaryLabel="Play Classic"
+      />
+    );
   }
 
-  if (backendUnavailable || !preloadedPuzzle) {
+  if (!preloadedPuzzle) {
+    logger.warn("[GroupsPage] Daily Groups puzzle unavailable during preload");
     return (
-      <GameModeLayout mode="groups">
-        <div className="flex flex-1 items-center px-4">
-          <GroupsUnavailableState
-            title="Groups Is Warming Up"
-            description="This build is connected to a backend that has not deployed the Groups queries yet. Classic and Order are still available, and Groups will light up once the Convex deploy completes."
-            primaryHref="/"
-            primaryLabel="Back to Home"
-            secondaryHref="/classic"
-            secondaryLabel="Play Classic"
-            className="my-auto"
-          />
-        </div>
-      </GameModeLayout>
+      <GameModeUnavailableState
+        mode="groups"
+        title="Groups Is Unavailable"
+        description="This build cannot load the daily Groups puzzle yet because the backend configuration or deployment is incomplete. Classic and Order remain available while Groups catches up."
+        primaryHref="/"
+        primaryLabel="Back to Home"
+        secondaryHref="/classic"
+        secondaryLabel="Play Classic"
+      />
     );
   }
 

--- a/src/app/(app)/order/page.test.tsx
+++ b/src/app/(app)/order/page.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const { preloadQueryMock, warnMock } = vi.hoisted(() => ({
+  preloadQueryMock: vi.fn(),
+  warnMock: vi.fn(),
+}));
+
+vi.mock("convex/nextjs", () => ({
+  preloadQuery: preloadQueryMock,
+}));
+
+vi.mock("@/lib/convexServer", () => ({
+  api: {
+    orderPuzzles: {
+      getDailyOrderPuzzle: "order-query",
+    },
+  },
+}));
+
+vi.mock("@/components/order/OrderGameIsland", () => ({
+  OrderGameIsland: ({ preloadedPuzzle }: { preloadedPuzzle: unknown }) => (
+    <div data-testid="order-game-island">{preloadedPuzzle ? "loaded" : "missing"}</div>
+  ),
+}));
+
+vi.mock("@/components/LoadingShell", () => ({
+  LoadingShell: () => <div data-testid="loading-shell">loading</div>,
+}));
+
+vi.mock("@/components/GameModeUnavailableState", () => ({
+  GameModeUnavailableState: ({ title }: { title: string }) => (
+    <div data-testid="mode-unavailable-state">{title}</div>
+  ),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: warnMock,
+  },
+}));
+
+import OrderPage from "@/app/(app)/order/page";
+
+describe("OrderPage", () => {
+  beforeEach(() => {
+    preloadQueryMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it("renders the order island when preload succeeds", async () => {
+    preloadQueryMock.mockResolvedValueOnce({ preloaded: true });
+
+    render(await OrderPage());
+
+    expect(screen.getByTestId("order-game-island")).toHaveTextContent("loaded");
+    expect(screen.queryByTestId("mode-unavailable-state")).not.toBeInTheDocument();
+  });
+
+  it("renders the unavailable state when preload returns null", async () => {
+    preloadQueryMock.mockResolvedValueOnce(null);
+
+    render(await OrderPage());
+
+    expect(screen.getByTestId("mode-unavailable-state")).toHaveTextContent("Order Is Unavailable");
+    expect(warnMock).toHaveBeenCalledWith(
+      "[OrderPage] Daily Order puzzle unavailable during preload",
+    );
+  });
+
+  it("renders the unavailable state for known backend-unavailable errors", async () => {
+    preloadQueryMock.mockRejectedValueOnce(
+      new Error("Environment variable NEXT_PUBLIC_CONVEX_URL is not set."),
+    );
+
+    render(await OrderPage());
+
+    expect(screen.getByTestId("mode-unavailable-state")).toHaveTextContent("Order Is Unavailable");
+    expect(warnMock).toHaveBeenCalledWith("[OrderPage] Failed to preload Order puzzle", {
+      error: expect.any(Error),
+    });
+  });
+
+  it("rethrows unexpected preload failures", async () => {
+    preloadQueryMock.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(OrderPage()).rejects.toThrow("boom");
+  });
+});

--- a/src/app/(app)/order/page.tsx
+++ b/src/app/(app)/order/page.tsx
@@ -2,12 +2,52 @@
 
 import React, { Suspense } from "react";
 import { preloadQuery } from "convex/nextjs";
+import { GameModeUnavailableState } from "@/components/GameModeUnavailableState";
 import { api } from "@/lib/convexServer";
 import { OrderGameIsland } from "@/components/order/OrderGameIsland";
 import { LoadingShell } from "@/components/LoadingShell";
+import { logger } from "@/lib/logger";
+import { isBackendUnavailablePreloadError } from "@/lib/preloadQueryAvailability";
 
 export default async function OrderPage() {
-  const preloadedPuzzle = await preloadQuery(api.orderPuzzles.getDailyOrderPuzzle);
+  let preloadedPuzzle = null;
+
+  try {
+    preloadedPuzzle = await preloadQuery(api.orderPuzzles.getDailyOrderPuzzle);
+  } catch (error) {
+    if (!isBackendUnavailablePreloadError(error)) {
+      throw error;
+    }
+
+    logger.warn("[OrderPage] Failed to preload Order puzzle", { error });
+    return (
+      <GameModeUnavailableState
+        mode="order"
+        title="Order Is Unavailable"
+        description="This build cannot load the daily Order puzzle yet because the backend configuration or deployment is incomplete. Classic remains available while Order catches up."
+        primaryHref="/"
+        primaryLabel="Back to Home"
+        secondaryHref="/classic"
+        secondaryLabel="Play Classic"
+      />
+    );
+  }
+
+  if (!preloadedPuzzle) {
+    logger.warn("[OrderPage] Daily Order puzzle unavailable during preload");
+    return (
+      <GameModeUnavailableState
+        mode="order"
+        title="Order Is Unavailable"
+        description="This build cannot load the daily Order puzzle yet because the backend configuration or deployment is incomplete. Classic remains available while Order catches up."
+        primaryHref="/"
+        primaryLabel="Back to Home"
+        secondaryHref="/classic"
+        secondaryLabel="Play Classic"
+      />
+    );
+  }
+
   return (
     <Suspense
       fallback={

--- a/src/components/GameModeUnavailableState.tsx
+++ b/src/components/GameModeUnavailableState.tsx
@@ -1,0 +1,38 @@
+import { GameModeLayout } from "@/components/GameModeLayout";
+import { ModeUnavailableState } from "@/components/ModeUnavailableState";
+
+interface GameModeUnavailableStateProps {
+  mode: "classic" | "order" | "groups";
+  title: string;
+  description: string;
+  primaryHref: string;
+  primaryLabel: string;
+  secondaryHref?: string;
+  secondaryLabel?: string;
+}
+
+export function GameModeUnavailableState({
+  mode,
+  title,
+  description,
+  primaryHref,
+  primaryLabel,
+  secondaryHref,
+  secondaryLabel,
+}: GameModeUnavailableStateProps) {
+  return (
+    <GameModeLayout mode={mode}>
+      <div className="flex flex-1 items-center px-4">
+        <ModeUnavailableState
+          title={title}
+          description={description}
+          primaryHref={primaryHref}
+          primaryLabel={primaryLabel}
+          secondaryHref={secondaryHref}
+          secondaryLabel={secondaryLabel}
+          className="my-auto"
+        />
+      </div>
+    </GameModeLayout>
+  );
+}

--- a/src/components/ModeUnavailableState.tsx
+++ b/src/components/ModeUnavailableState.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 
-interface GroupsUnavailableStateProps {
+interface ModeUnavailableStateProps {
   title: string;
   description: string;
   primaryHref: string;
@@ -11,7 +11,7 @@ interface GroupsUnavailableStateProps {
   className?: string;
 }
 
-export function GroupsUnavailableState({
+export function ModeUnavailableState({
   title,
   description,
   primaryHref,
@@ -19,7 +19,7 @@ export function GroupsUnavailableState({
   secondaryHref,
   secondaryLabel,
   className,
-}: GroupsUnavailableStateProps) {
+}: ModeUnavailableStateProps) {
   return (
     <section
       className={cn(

--- a/src/components/__tests__/providers.test.tsx
+++ b/src/components/__tests__/providers.test.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("@clerk/nextjs", () => ({
+  ClerkProvider: ({
+    children,
+    publishableKey,
+  }: {
+    children: React.ReactNode;
+    publishableKey: string;
+  }) => (
+    <div data-testid="clerk-provider" data-publishable-key={publishableKey}>
+      {children}
+    </div>
+  ),
+  useAuth: () => ({ isSignedIn: false }),
+}));
+
+vi.mock("convex/react", () => ({
+  ConvexReactClient: class MockConvexReactClient {
+    constructor(_url: string) {}
+  },
+}));
+
+vi.mock("convex/react-clerk", () => ({
+  ConvexProviderWithClerk: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="convex-provider">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/SessionThemeProvider", () => ({
+  SessionThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ErrorBoundary", () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/UserCreationProvider", () => ({
+  UserCreationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/providers/MigrationProvider", () => ({
+  MigrationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/observability/sentry.client", () => ({
+  initSentryClient: vi.fn(),
+}));
+
+const ORIGINAL_CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL;
+const ORIGINAL_CLERK_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+async function loadProviders() {
+  vi.resetModules();
+  return await import("@/components/providers");
+}
+
+describe("Providers", () => {
+  afterEach(() => {
+    cleanup();
+
+    if (ORIGINAL_CONVEX_URL === undefined) {
+      delete process.env.NEXT_PUBLIC_CONVEX_URL;
+    } else {
+      process.env.NEXT_PUBLIC_CONVEX_URL = ORIGINAL_CONVEX_URL;
+    }
+
+    if (ORIGINAL_CLERK_KEY === undefined) {
+      delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    } else {
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = ORIGINAL_CLERK_KEY;
+    }
+  });
+
+  it("renders configuration error when required public env vars are missing", async () => {
+    delete process.env.NEXT_PUBLIC_CONVEX_URL;
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+    const { Providers } = await loadProviders();
+
+    render(
+      <Providers>
+        <div>app-shell</div>
+      </Providers>,
+    );
+
+    expect(screen.getByText("Configuration Error")).toBeInTheDocument();
+    expect(screen.getByText("NEXT_PUBLIC_CONVEX_URL")).toBeInTheDocument();
+    expect(screen.getByText("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY")).toBeInTheDocument();
+    expect(screen.queryByText("app-shell")).not.toBeInTheDocument();
+  });
+
+  it("renders the application tree when required public env vars exist", async () => {
+    process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.convex.cloud";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_example";
+
+    const { Providers } = await loadProviders();
+
+    render(
+      <Providers>
+        <div>app-shell</div>
+      </Providers>,
+    );
+
+    expect(screen.getByTestId("clerk-provider")).toHaveAttribute(
+      "data-publishable-key",
+      "pk_test_example",
+    );
+    expect(screen.getByTestId("convex-provider")).toBeInTheDocument();
+    expect(screen.getByText("app-shell")).toBeInTheDocument();
+  });
+
+  it("reads env vars at render time instead of import time", async () => {
+    process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.convex.cloud";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_example";
+
+    const { Providers } = await loadProviders();
+
+    const { rerender } = render(
+      <Providers>
+        <div>app-shell</div>
+      </Providers>,
+    );
+
+    expect(screen.getByText("app-shell")).toBeInTheDocument();
+
+    delete process.env.NEXT_PUBLIC_CONVEX_URL;
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+    rerender(
+      <Providers>
+        <div>app-shell</div>
+      </Providers>,
+    );
+
+    expect(screen.getByText("Configuration Error")).toBeInTheDocument();
+    expect(screen.queryByText("app-shell")).not.toBeInTheDocument();
+  });
+
+  it("treats blank public env vars as missing configuration", async () => {
+    process.env.NEXT_PUBLIC_CONVEX_URL = "   ";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "\n";
+
+    const { Providers } = await loadProviders();
+
+    render(
+      <Providers>
+        <div>app-shell</div>
+      </Providers>,
+    );
+
+    expect(screen.getByText("Configuration Error")).toBeInTheDocument();
+    expect(screen.getByText("NEXT_PUBLIC_CONVEX_URL")).toBeInTheDocument();
+    expect(screen.getByText("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY")).toBeInTheDocument();
+    expect(screen.queryByText("app-shell")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -8,21 +8,25 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { UserCreationProvider } from "@/components/UserCreationProvider";
 import { MigrationProvider } from "@/components/providers/MigrationProvider";
 import { ToastProvider } from "@/hooks/use-toast";
-import { validateEnvironment, getEnvErrorMessage, isProduction } from "@/lib/env";
+import { getEnvErrorMessage, getMissingPublicBootstrapEnvVars, isProduction } from "@/lib/env";
 import { initSentryClient } from "@/observability/sentry.client";
 
 // Initialize Sentry at module scope (before React components render)
 // This ensures Sentry is ready before any component can call captureClientException
 initSentryClient();
 
-// Validate environment variables using enhanced validation
-const envValidation = validateEnvironment();
-const missingEnvVars = envValidation.missingVars;
+const convexClients = new Map<string, ConvexReactClient>();
 
-// Only initialize Convex client if we have the URL
-const convex = process.env.NEXT_PUBLIC_CONVEX_URL
-  ? new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL)
-  : null;
+function getOrCreateConvexClient(url: string): ConvexReactClient {
+  const existingClient = convexClients.get(url);
+  if (existingClient) {
+    return existingClient;
+  }
+
+  const client = new ConvexReactClient(url);
+  convexClients.set(url, client);
+  return client;
+}
 
 // Component to display when environment variables are missing
 function MissingEnvironmentVariables({ variables }: { variables: string[] }) {
@@ -89,8 +93,11 @@ function MissingEnvironmentVariables({ variables }: { variables: string[] }) {
 }
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  // Show error UI if environment variables are missing
-  if (missingEnvVars.length > 0) {
+  const missingEnvVars = getMissingPublicBootstrapEnvVars();
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL?.trim();
+  const clerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.trim();
+
+  if (missingEnvVars.length > 0 || !convexUrl || !clerkKey) {
     return (
       <ErrorBoundary>
         <MissingEnvironmentVariables variables={missingEnvVars} />
@@ -98,15 +105,14 @@ export function Providers({ children }: { children: React.ReactNode }) {
     );
   }
 
-  // TypeScript knows these are defined now due to the check above
-  const clerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY!;
+  const convex = getOrCreateConvexClient(convexUrl);
 
   return (
     <ErrorBoundary>
       <ToastProvider>
         <MigrationProvider>
           <ClerkProvider publishableKey={clerkKey} dynamic>
-            <ConvexProviderWithClerk client={convex!} useAuth={useAuth}>
+            <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
               <UserCreationProvider>
                 <SessionThemeProvider>{children}</SessionThemeProvider>
               </UserCreationProvider>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -8,7 +8,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { UserCreationProvider } from "@/components/UserCreationProvider";
 import { MigrationProvider } from "@/components/providers/MigrationProvider";
 import { ToastProvider } from "@/hooks/use-toast";
-import { getEnvErrorMessage, getMissingPublicBootstrapEnvVars, isProduction } from "@/lib/env";
+import { getEnvErrorMessage, getPublicBootstrapEnv, isProduction } from "@/lib/env";
 import { initSentryClient } from "@/observability/sentry.client";
 
 // Initialize Sentry at module scope (before React components render)
@@ -93,9 +93,11 @@ function MissingEnvironmentVariables({ variables }: { variables: string[] }) {
 }
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  const missingEnvVars = getMissingPublicBootstrapEnvVars();
-  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL?.trim();
-  const clerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.trim();
+  const {
+    missingVars: missingEnvVars,
+    convexUrl,
+    clerkPublishableKey: clerkKey,
+  } = getPublicBootstrapEnv();
 
   if (missingEnvVars.length > 0 || !convexUrl || !clerkKey) {
     return (

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -13,6 +13,20 @@ interface EnvValidationResult {
   warnings: string[];
 }
 
+const REQUIRED_PUBLIC_BOOTSTRAP_ENV_VARS = [
+  "NEXT_PUBLIC_CONVEX_URL",
+  "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+] as const;
+
+function hasNonEmptyEnvVar(key: string): boolean {
+  const value = process.env[key];
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function getMissingPublicBootstrapEnvVars(): string[] {
+  return REQUIRED_PUBLIC_BOOTSTRAP_ENV_VARS.filter((key) => !hasNonEmptyEnvVar(key));
+}
+
 /**
  * Validates all required environment variables (client and server)
  * @returns Validation result with missing variables
@@ -35,14 +49,9 @@ export function validateEnvironment(): EnvValidationResult {
     warnings: [],
   };
 
-  // Check required client-side variables
-  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
-    result.missingVars.push("NEXT_PUBLIC_CONVEX_URL");
-    result.isValid = false;
-  }
-
-  if (!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) {
-    result.missingVars.push("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY");
+  const missingPublicVars = getMissingPublicBootstrapEnvVars();
+  if (missingPublicVars.length > 0) {
+    result.missingVars.push(...missingPublicVars);
     result.isValid = false;
   }
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -18,13 +18,39 @@ const REQUIRED_PUBLIC_BOOTSTRAP_ENV_VARS = [
   "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
 ] as const;
 
-function hasNonEmptyEnvVar(key: string): boolean {
-  const value = process.env[key];
-  return typeof value === "string" && value.trim().length > 0;
+type PublicBootstrapEnvKey = (typeof REQUIRED_PUBLIC_BOOTSTRAP_ENV_VARS)[number];
+
+interface PublicBootstrapEnv {
+  convexUrl: string | null;
+  clerkPublishableKey: string | null;
+  missingVars: PublicBootstrapEnvKey[];
 }
 
-export function getMissingPublicBootstrapEnvVars(): string[] {
-  return REQUIRED_PUBLIC_BOOTSTRAP_ENV_VARS.filter((key) => !hasNonEmptyEnvVar(key));
+function normalizeEnvValue(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function getPublicBootstrapEnv(): PublicBootstrapEnv {
+  // Use static NEXT_PUBLIC property access so Next can inline these values in
+  // the client bundle. Dynamic process.env indexing is not reliable here.
+  const envValues: Record<PublicBootstrapEnvKey, string | null> = {
+    NEXT_PUBLIC_CONVEX_URL: normalizeEnvValue(process.env.NEXT_PUBLIC_CONVEX_URL),
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: normalizeEnvValue(
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    ),
+  };
+  const missingVars = REQUIRED_PUBLIC_BOOTSTRAP_ENV_VARS.filter((key) => !envValues[key]);
+
+  return {
+    convexUrl: envValues.NEXT_PUBLIC_CONVEX_URL,
+    clerkPublishableKey: envValues.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    missingVars,
+  };
+}
+
+export function getMissingPublicBootstrapEnvVars(): PublicBootstrapEnvKey[] {
+  return getPublicBootstrapEnv().missingVars;
 }
 
 /**

--- a/src/lib/preloadQueryAvailability.ts
+++ b/src/lib/preloadQueryAvailability.ts
@@ -1,0 +1,14 @@
+const UNAVAILABLE_PRELOAD_PATTERNS = [
+  /next_public_convex_url is not set/i,
+  /could not find public function/i,
+  /public function .* not found/i,
+  /query .* not found/i,
+];
+
+export function isBackendUnavailablePreloadError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return UNAVAILABLE_PRELOAD_PATTERNS.some((pattern) => pattern.test(error.message));
+}


### PR DESCRIPTION
## Summary
- harden env-less and partially deployed builds so Order and Groups fail closed instead of crashing
- stabilize Dagger quality runs by using a non-incremental TypeScript CI entrypoint
- add regression coverage for provider bootstrap env handling, bounded preload fallbacks, and admin dashboard dynamic rendering

## Verification
- bun run type-check
- bun run lint
- bun run test
- pre-push checks
- prior full Dagger `check` on this commit line


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New unified unavailable-state UI for game modes (Classic/Order/Groups).
  * Admin dashboard forced to dynamic rendering to avoid build-time config issues.

* **Bug Fixes**
  * Graceful, bounded fallbacks for known backend-unavailable errors when loading puzzles.
  * Preload errors now rethrow unexpected failures while handling known outages.

* **Tests**
  * Added regression tests for missing/blank public env vars and new fallback paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->