### PR TITLE
ci(stripe): automate webhook redirect check from INCIDENT-2026-01-17T.md

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,12 +2,13 @@
 
 ## Workflows Overview
 
-| Workflow                 | Trigger                  | Purpose                                 |
-| ------------------------ | ------------------------ | --------------------------------------- |
-| `ci.yml`                 | PR & push to main/master | Quality checks, tests, build validation |
-| `deploy.yml`             | Push to main/master      | Production deployment                   |
-| `size-limit.yml`         | PR                       | Bundle size checks                      |
-| `claude-code-review.yml` | PR                       | Automated code review                   |
+| Workflow                   | Trigger                      | Purpose                                                                              |
+| -------------------------- | ---------------------------- | ------------------------------------------------------------------------------------ |
+| `ci.yml`                   | PR & push to main/master     | Quality checks, tests, build validation                                              |
+| `deploy.yml`               | Push to main/master          | Production deployment                                                                |
+| `size-limit.yml`           | PR                           | Bundle size checks                                                                   |
+| `claude-code-review.yml`   | PR                           | Automated code review                                                                |
+| `webhook-health-check.yml` | Schedule (every 6h) & manual | Fails if the production Stripe webhook route redirects (see INCIDENT-2026-01-17T.md) |
 
 ## Required GitHub Secrets
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -81,6 +81,16 @@ Steps:
 5. Build Next.js application
 6. Deploy to Convex production
 7. Verify deployment
+8. Verify the Stripe webhook route doesn't redirect (`verify:webhook`)
+
+### Webhook Health Check (`webhook-health-check.yml`)
+
+Runs `verify:webhook` (`scripts/verify-webhook-redirect.mjs`) against the
+production Stripe webhook route every 6 hours and on manual dispatch. Stripe
+does not follow redirects when delivering webhooks, so a 3xx here means
+webhook events are being silently dropped (see `INCIDENT-2026-01-17T.md`).
+Scheduled separately from deploys because the root cause — a domain-level
+redirect — can drift without a code push.
 
 ### CI (`ci.yml`)
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,6 +151,14 @@ jobs:
         env:
           NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
 
+      # Step 7: Guard against a repeat of INCIDENT-2026-01-17T.md (Stripe does
+      # not follow redirects; a 3xx here silently drops every webhook event).
+      # Vercel's own deploy runs outside this workflow, so this checks the
+      # domain-level routing that's currently live rather than this push's
+      # build specifically.
+      - name: Verify Stripe webhook route does not redirect
+        run: bun run verify:webhook
+
       # Optional: Deploy to Vercel (if using Vercel for hosting)
       # Uncomment the following if deploying to Vercel
       # - name: Deploy to Vercel

--- a/.github/workflows/webhook-health-check.yml
+++ b/.github/workflows/webhook-health-check.yml
@@ -1,0 +1,25 @@
+name: Webhook Health Check
+
+# Automates the redirect check from INCIDENT-2026-01-17T.md: Stripe does not
+# follow redirects, so a webhook URL that starts 3xx-ing silently drops every
+# event. This runs independently of deploys because the incident's root
+# cause (a domain-level redirect) can change without a code push.
+
+on:
+  schedule:
+    - cron: "17 */6 * * *" # every 6 hours
+  workflow_dispatch: {}
+
+jobs:
+  check-webhook-redirect:
+    name: Check Stripe webhook route for redirects
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Verify production webhook route does not redirect
+        run: bun run verify:webhook

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "verify:env:prod": "node scripts/verify-env-config.mjs production",
     "verify:stripe": "node scripts/verify-stripe-config.mjs",
     "verify:stripe:live": "node scripts/verify-stripe-config.mjs --live",
+    "verify:webhook": "node scripts/verify-webhook-redirect.mjs",
     "verify:vercel": "node scripts/verify-vercel-env.mjs",
     "changeset": "changeset",
     "changeset:version": "changeset version",

--- a/scripts/verify-webhook-redirect.mjs
+++ b/scripts/verify-webhook-redirect.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Stripe Webhook Redirect Guard
+ *
+ * Stripe does not follow HTTP redirects when delivering webhooks (see
+ * INCIDENT-2026-01-17T.md: a 307 from chrondle.app -> www.chrondle.app
+ * silently dropped every webhook for ~30 minutes). This script requests the
+ * production webhook route directly, without following redirects, and fails
+ * if the response is a 3xx.
+ *
+ * A non-redirect response (2xx/4xx) is healthy: Stripe's real POSTs carry a
+ * signature this route will reject with 4xx, which is exactly what a
+ * reachable, non-redirecting endpoint looks like from the outside. The only
+ * failure mode this script exists to catch is a 3xx, because that's the one
+ * Stripe cannot recover from.
+ *
+ * Usage:
+ *   node scripts/verify-webhook-redirect.mjs [url]
+ *
+ * Environment:
+ *   WEBHOOK_URL   Overrides the URL to check (default below)
+ *
+ * Exit codes:
+ *   0 = no redirect observed
+ *   1 = redirect observed, or request could not be made
+ */
+
+const DEFAULT_URL = "https://www.chrondle.app/api/webhooks/stripe";
+
+async function main() {
+  const url = process.argv[2] || process.env.WEBHOOK_URL || DEFAULT_URL;
+
+  console.log(`Checking webhook route for redirects: ${url}`);
+
+  let response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      redirect: "manual",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+  } catch (error) {
+    console.error(`FAIL: request to ${url} did not complete: ${error.message}`);
+    process.exit(1);
+  }
+
+  const { status } = response;
+
+  if (status >= 300 && status < 400) {
+    const location = response.headers.get("location") || "(no Location header)";
+    console.error(
+      `FAIL: ${url} returned ${status} (redirect to ${location}).\n` +
+        "Stripe does not follow redirects for webhook delivery — this endpoint " +
+        "would silently drop every webhook event (see INCIDENT-2026-01-17T.md).",
+    );
+    process.exit(1);
+  }
+
+  console.log(`OK: ${url} returned ${status} (no redirect)`);
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Automates the manual runbook check from `INCIDENT-2026-01-17T.md`: Stripe does not follow redirects for webhook delivery, so a 3xx on the webhook route silently drops every event (this happened for ~30 minutes on 2026-01-17 via a `chrondle.app` -> `www.chrondle.app` 307).
- Adds `scripts/verify-webhook-redirect.mjs`: a dependency-free check that POSTs the production webhook route with `redirect: "manual"` and fails on any 3xx.
- Wires it into a new scheduled workflow (`webhook-health-check.yml`, every 6h + `workflow_dispatch`) — scheduled independently of deploys because the incident's root cause (a domain-level redirect) can drift without a code push, e.g. a Vercel domain setting changing outside of git.
- Also runs it as a post-deploy smoke step in `deploy.yml` for defense in depth.

## Why a live check, not a static config check
`next.config.ts` has no `redirects()`/`trailingSlash` entry for `www` canonicalization, and there's no `vercel.json` domain config in this repo — the apex → www redirect that caused the incident lives in Vercel's project/domain settings, outside version control. A static repo-config check would not catch this incident class; only requesting the live route does. Confirmed against production right now:
- `https://www.chrondle.app/api/webhooks/stripe` (the configured Stripe endpoint) → `400` (reachable, no redirect) ✅
- `https://chrondle.app/api/webhooks/stripe` (apex) → `307` (still redirects, as expected/desired for normal traffic, but would be exactly the failure mode if the webhook URL were ever reconfigured back to apex)

## Test plan
- [x] `node scripts/verify-webhook-redirect.mjs` against production `www.chrondle.app` → passes (400, no redirect)
- [x] `node scripts/verify-webhook-redirect.mjs https://chrondle.app/api/webhooks/stripe` → correctly fails (307 redirect detected)
- [x] `bun run type-check` — clean
- [x] `npx eslint scripts/verify-webhook-redirect.mjs` — clean
- [x] YAML validated for both workflow files
- [ ] CI green on this PR (workflow only runs on schedule/dispatch, not on PR — the `deploy.yml` change will exercise on merge to master)

Not merging — opening for review per triage instructions.