### PR TITLE
ci(review): pin claude-review to a live model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin a live model — the action default (claude-sonnet-4-20250514) was retired and 404s
+          model: "claude-sonnet-5"
           
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |


### PR DESCRIPTION
Every claude-review run repo-wide fails in ~29s: the action's default model (claude-sonnet-4-20250514) is retired and 404s. Pins claude-sonnet-5 explicitly. Found while triaging chrondle-905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)