### PR TITLE
fix(test): stop convex-edge project inheriting unit-test include pattern

### DIFF
--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -1,11 +1,44 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import { baseVitestConfig } from "./vitest.config";
 
+// Root cause (see chrondle-eng-convex-edge-tests): each project in
+// `baseVitestConfig.test.projects` declares `extends: true`, which makes
+// Vitest re-resolve THIS file as that project's "root" config and merge its
+// root-level `test.include` into the project's own `include` via Vite's
+// `mergeConfig` — which concatenates arrays instead of letting the more
+// specific project-level `include` win. Previously this file set
+// `test.include` at the top level, so the broad unit-test pattern below
+// leaked into the `convex-edge` project (env `edge-runtime`, no `document`)
+// on top of its intentionally narrow `convex/**/*.convex.test.ts` include,
+// causing every DOM-rendering unit test to *also* run there and crash with
+// "Cannot read properties of undefined (reading 'body')".
+//
+// Fix: never set `test.include` at the root of this file. Instead, apply
+// the unit-test scoping directly to the individual project(s) that should
+// be scoped to it, by rebuilding `test.projects` via plain object spread
+// (not `mergeConfig`, which would concatenate rather than replace). The
+// `convex-edge` project is left untouched so its include stays exclusive.
+const UNIT_TEST_INCLUDE = ["**/*.unit.test.{ts,tsx}"];
+
+const scopedProjects = baseVitestConfig.test.projects.map((project) =>
+  project.test.name === "convex-edge"
+    ? project
+    : {
+        ...project,
+        test: { ...project.test, include: UNIT_TEST_INCLUDE },
+      },
+);
+
 export default mergeConfig(
-  baseVitestConfig,
+  {
+    ...baseVitestConfig,
+    test: {
+      ...baseVitestConfig.test,
+      projects: scopedProjects,
+    },
+  },
   defineConfig({
     test: {
-      include: ["**/*.unit.test.{ts,tsx}"],
       // Unit tests should be fast, reduce timeout
       testTimeout: 5000,
       hookTimeout: 5000,


### PR DESCRIPTION
## Summary
- `bun run test:unit` was failing 6 tests with `Cannot read properties of undefined (reading 'body')` because Vitest's `extends: true` project resolution concatenates the root `test.include` from `vitest.config.unit.ts` into every project's own `include` array (Vite's `mergeConfig` array behavior), so the DOM-free `convex-edge` project (environment `edge-runtime`) started running React-rendering unit tests meant for the jsdom `default` project.
- Fix: never set `test.include` at this file's root. Rebuild `test.projects` via plain object spread (not `mergeConfig`) so only the `default` project gets the unit-test include pattern; `convex-edge`'s own narrow include is left untouched.
- `bun run test:unit` now runs the correct 24 distinct files / 332 tests, 0 failures, no duplication — matches `bun run test:ci` (`vitest run` against `vitest.config.ts` directly), which was never affected since it never sets a root include. No gate-parity gap to close.

## Test plan
- [x] `bun run test:unit` — 24 files, 332 tests, 0 failures (previously 3 files / 6 tests failing on a clean checkout)
- [x] `bun run test:ci` (`vitest run`) — 150 passed | 1 skipped (151 files), 1970 passed | 3 skipped (1973 tests) — unaffected, confirms gate parity
- [x] `bun run type-check` — clean
- [x] `bun run lint` — no new errors introduced (pre-existing errors are in untracked `check-lab001*.mjs` scratch files from a concurrent session, not touched by this PR)

Card: chrondle-eng-convex-edge-tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)