### PR TITLE
fix(daily): one local-day "today" across gallery, game pages, countdown, and streaks

### DIFF
--- a/.backlog.d/007-unify-puzzle-date-semantics-and-docs.md
+++ b/.backlog.d/007-unify-puzzle-date-semantics-and-docs.md
@@ -1,24 +1,29 @@
 # Unify puzzle date semantics and docs
 
 Priority: high
-Status: ready
+Status: absorbed
+Absorbed-By: Powder card chrondle-ux-daily-identity (PR: fix/daily-identity-local-day)
 Estimate: M
 
 ## Goal
+
 Choose one explicit daily-puzzle date model across classic mode, Order mode, countdown behavior, and project documentation, then make the implementation and docs agree.
 
 ## Non-Goals
+
 - Change historical scoring or archive visibility policy
 - Introduce answer-leaking timing hints
 - Bundle unrelated cron infrastructure cleanup into the same diff
 
 ## Oracle
+
 - [ ] [behavioral] Classic and Order daily puzzle retrieval follow the same documented date semantics.
 - [ ] [behavioral] Countdown text and rollover behavior match the chosen semantics.
 - [ ] [test] Add or update coverage for the chosen date boundary behavior.
 - [ ] [command] `bun run lint && bun run type-check && bun run test`
 
 ## Notes
+
 - Related GitHub issues: `#99`
 - Evidence: code comments in [GameIsland.tsx](/Users/phaedrus/.codex/worktrees/087b/chrondle/src/components/GameIsland.tsx) and hooks under `src/hooks/useTodaysPuzzle.ts` describe local-date behavior, while repo docs still describe Central Time or UTC-centric scheduling in multiple places.
 - Touchpoints: `src/hooks/useTodaysPuzzle.ts`, `src/hooks/useTodaysOrderPuzzle.ts`, `src/hooks/useCountdown.ts`, `convex/puzzles/queries.ts`, `convex/orderPuzzles/queries.ts`, `README.md`, `CLAUDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,20 @@ Never reveal the answer outside the hint system. No "smart" era selection. No "t
 - Deterministic hash selects year daily → events for that year = hints
 - Same date = same puzzle globally
 
+**Daily Day Semantics (canonical — do not re-litigate per surface):**
+
+- "Today" is the **player's local calendar day**. The single day-resolution
+  module is `src/lib/time/dailyDate.ts`; UI resolves puzzles by explicit date
+  (`getPuzzleByDate` / `getOrderPuzzleByDate`) via `useTodaysPuzzle` /
+  `useTodaysOrderPuzzle`. The countdown targets local midnight.
+- Never resolve a UI "today" from a server clock. `getDailyPuzzle` /
+  `getDailyOrderPuzzle` (UTC-day) are quarantined for stale clients only and
+  lint-banned in `src/`.
+- Streak boundaries derive from the **puzzle's date**; a puzzle is "daily"
+  when its date is within one day of server-UTC (timezone envelope). See
+  `convex/lib/puzzleType.ts`, `convex/lib/streakHelpers.ts`, and the
+  "Daily Day Semantics" section of README.md for the full rationale.
+
 **Convex Deployments:**
 
 - **DEV:** `handsome-raccoon-955` (for development)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - **Historical Range:** Puzzles cover a vast timeline, from ancient civilizations to recent events.
 - **Dynamic Puzzle Generation:** Puzzles are created on-demand each day from our events database using a deterministic algorithm - ensuring the same puzzle globally for all players.
 - **Daily Notifications:** Optional reminders to play each day's puzzle, with customizable notification times.
-- **Smart Timezone Handling:** Daily puzzle resets at midnight Central Time, automatically adjusting for daylight saving time transitions.
+- **Local-Day Puzzles:** "Today" is your local calendar day — the daily puzzle rolls over at YOUR midnight, and every surface (homepage, game pages, archive, countdown, streaks) agrees on which puzzle is today's.
 
 ## Daily Notifications
 
@@ -102,34 +102,34 @@ Chrondle supports both anonymous and authenticated gameplay:
 
 ## Technical Architecture
 
-### Daily Puzzle Scheduling
+### Daily Day Semantics (canonical)
 
-Chrondle implements sophisticated scheduling to ensure puzzles reset at midnight Central Time:
+Chrondle's canonical "today" is the **player's local calendar day**.
 
-#### DST-Aware Cron System
-
-- **Automatic DST Handling:** The system detects whether Central Time is in CST (UTC-6) or CDT (UTC-5)
-- **Daily Recalculation:** UTC offset is computed daily to handle DST transitions seamlessly
-- **Spring Forward/Fall Back:** Correctly handles the twice-yearly time changes without manual intervention
-- **Global Consistency:** All players worldwide receive the same puzzle at Central Time midnight
-
-#### Implementation Details
-
-```typescript
-// Dynamic UTC hour calculation for Central Time midnight
-function getUTCHourForCentralMidnight(): number {
-  const now = new Date();
-  const chicagoTime = new Date(now.toLocaleString("en-US", {
-    timeZone: "America/Chicago"
-  }));
-  const isDST = /* DST detection logic */;
-  return isDST ? 5 : 6; // UTC 5 AM (CDT) or 6 AM (CST)
-}
-```
-
-- **Convex Cron Jobs:** Backend scheduled tasks run at the calculated UTC hour
-- **Timezone Library:** Uses standard IANA timezone database (America/Chicago)
-- **Edge Case Handling:** Properly manages the ambiguous hour during "fall back"
+- **Why:** the daily ritual should roll over at the player's own midnight. A
+  server-clock day (UTC or any fixed timezone) would flip the puzzle mid-evening
+  for most of the world and make surfaces disagree about which puzzle is
+  "today's" — exactly the bug this rule replaced (the homepage once advertised
+  tomorrow's UTC puzzle while game pages played today's local one).
+- **How:** the single day-resolution module is
+  [`src/lib/time/dailyDate.ts`](src/lib/time/dailyDate.ts)
+  (`getLocalDateString` and `getMillisUntilLocalMidnight`). Clients resolve
+  their local date and query puzzles **by explicit date**
+  (`puzzles.getPuzzleByDate` / `orderPuzzles.getOrderPuzzleByDate`). The
+  homepage gallery, game pages, and archive all consume the same local-date
+  hooks (`useTodaysPuzzle`, `useTodaysOrderPuzzle`); the countdown targets
+  local midnight.
+- **Server rules:** Convex code never resolves a UI "today" from its own
+  clock. The quarantined UTC-day queries (`getDailyPuzzle`,
+  `getDailyOrderPuzzle`) exist only for stale client bundles and are
+  lint-banned in `src/` (`no-restricted-syntax`). Streak boundaries derive
+  from the **puzzle's date** (consecutive puzzle dates = consecutive days); a
+  puzzle counts as daily when its date is within one day of the server's UTC
+  date — the timezone envelope (UTC-12..UTC+14). See
+  `convex/lib/puzzleType.ts` and `convex/lib/streakHelpers.ts`.
+- **Generation:** cron pre-generates puzzles around the UTC day so a puzzle
+  row exists for every local "today" on Earth; if a client's local date has no
+  puzzle yet, the client triggers on-demand generation (`ensurePuzzleForDate`).
 
 ### Notification System Architecture
 
@@ -340,7 +340,8 @@ bun run verify:convex
 **Daily puzzle timing:**
 
 - Confirm cron job is running (check Convex dashboard logs)
-- Verify DST calculations are correct for current date
-- Check that server timezone handling matches Central Time
+- Remember "today" is the PLAYER'S local calendar day (see Daily Day Semantics
+  above) — a puzzle number that differs between two machines usually means the
+  machines are on different local dates, not a bug
 
 For more detailed setup instructions, see the [Convex Next.js Quickstart](https://docs.convex.dev/quickstart/nextjs) and [Clerk Next.js Documentation](https://clerk.com/docs/quickstarts/nextjs).

--- a/convex/__tests__/archivePuzzleStreak.test.ts
+++ b/convex/__tests__/archivePuzzleStreak.test.ts
@@ -1,208 +1,145 @@
 import { describe, it, expect } from "vitest";
+import { shouldUpdateStreakForPuzzle } from "../lib/streakHelpers";
 
 /**
  * Tests for archive puzzle streak isolation
  *
- * These tests verify that playing historical/archive puzzles does NOT
- * affect the user's daily streak. Only today's daily puzzle should
- * update streak counts.
+ * These tests exercise the REAL streak-guard decision used by
+ * updateUserStreak (convex/lib/streakHelpers.ts).
+ *
+ * Day semantics: Chrondle's canonical "today" is the PLAYER'S local calendar
+ * day, so a puzzle counts as "daily" when its date is within one day of the
+ * server's UTC date (the timezone envelope, UTC-12..UTC+14). Genuinely
+ * historical puzzles (2+ days out) must NEVER touch the streak, and playing
+ * an older-dated puzzle after a newer completion must never rewind it.
  *
  * This prevents gaming the system by:
- * - Keeping streaks alive with archive puzzles
  * - Reviving dead streaks with historical completions
- * - Avoiding today's daily puzzle consequences
+ * - Rewinding/resetting a streak by replaying an older day's puzzle
+ * - Avoiding today's puzzle consequences with archive plays
  */
 describe("Archive Puzzle Streak Isolation", () => {
-  /**
-   * Helper to simulate streak update decision logic
-   *
-   * Mimics the guard check in convex/puzzles.ts:updateUserStreak()
-   */
-  function shouldUpdateStreak(puzzleDate: string, today: string): boolean {
-    return puzzleDate === today;
-  }
+  describe("Daily Puzzle Behavior (timezone envelope)", () => {
+    it("updates streak when puzzle date matches server UTC today", () => {
+      const decision = shouldUpdateStreakForPuzzle("2025-10-12", "2025-10-11", "2025-10-12");
 
-  describe("Daily Puzzle Behavior", () => {
-    it("should update streak when playing today's daily puzzle", () => {
-      const today = "2025-10-12";
-      const puzzleDate = "2025-10-12"; // Same as today
-
-      const shouldUpdate = shouldUpdateStreak(puzzleDate, today);
-
-      expect(shouldUpdate).toBe(true);
+      expect(decision).toEqual({ update: true, reason: "daily" });
     });
 
-    it("should update streak for multiple plays on same day's puzzle", () => {
-      const today = "2025-10-12";
-      const puzzleDate = "2025-10-12";
+    it("updates streak when puzzle date is one day behind UTC (evening local play)", () => {
+      // After 00:00 UTC, a US player's daily puzzle is dated UTC-yesterday.
+      const decision = shouldUpdateStreakForPuzzle("2025-10-11", "2025-10-10", "2025-10-12");
 
-      // First play
-      expect(shouldUpdateStreak(puzzleDate, today)).toBe(true);
+      expect(decision).toEqual({ update: true, reason: "daily" });
+    });
 
-      // Second play (same-day replay handled by calculateStreakUpdate logic)
-      expect(shouldUpdateStreak(puzzleDate, today)).toBe(true);
+    it("updates streak when puzzle date is one day ahead of UTC (UTC+14 morning play)", () => {
+      const decision = shouldUpdateStreakForPuzzle("2025-10-13", "2025-10-12", "2025-10-12");
+
+      expect(decision).toEqual({ update: true, reason: "daily" });
+    });
+
+    it("allows same-day replay through to calculateStreakUpdate (which no-ops)", () => {
+      const decision = shouldUpdateStreakForPuzzle("2025-10-12", "2025-10-12", "2025-10-12");
+
+      expect(decision).toEqual({ update: true, reason: "daily" });
     });
   });
 
   describe("Archive Puzzle Behavior", () => {
-    it("should NOT update streak when playing yesterday's puzzle", () => {
-      const today = "2025-10-12";
-      const puzzleDate = "2025-10-11"; // Yesterday
+    it.each([
+      ["two days ago", "2025-10-10"],
+      ["last week", "2025-10-05"],
+      ["last month", "2025-09-12"],
+      ["last year", "2024-10-12"],
+      ["very old", "2020-01-01"],
+    ])("does NOT update streak when playing %s puzzle", (_label, puzzleDate) => {
+      const decision = shouldUpdateStreakForPuzzle(puzzleDate, null, "2025-10-12");
 
-      const shouldUpdate = shouldUpdateStreak(puzzleDate, today);
-
-      expect(shouldUpdate).toBe(false);
+      expect(decision).toEqual({ update: false, reason: "archive" });
     });
 
-    it("should NOT update streak when playing last week's puzzle", () => {
-      const today = "2025-10-12";
-      const puzzleDate = "2025-10-05"; // 7 days ago
+    it("does NOT update streak for a far-future puzzle date", () => {
+      const decision = shouldUpdateStreakForPuzzle("2025-10-14", null, "2025-10-12");
 
-      const shouldUpdate = shouldUpdateStreak(puzzleDate, today);
-
-      expect(shouldUpdate).toBe(false);
-    });
-
-    it("should NOT update streak when playing last month's puzzle", () => {
-      const today = "2025-10-12";
-      const puzzleDate = "2025-09-12"; // 30 days ago
-
-      const shouldUpdate = shouldUpdateStreak(puzzleDate, today);
-
-      expect(shouldUpdate).toBe(false);
-    });
-
-    it("should NOT update streak when playing last year's puzzle", () => {
-      const today = "2025-10-12";
-      const puzzleDate = "2024-10-12"; // 365 days ago
-
-      const shouldUpdate = shouldUpdateStreak(puzzleDate, today);
-
-      expect(shouldUpdate).toBe(false);
-    });
-
-    it("should NOT update streak when playing very old puzzle", () => {
-      const today = "2025-10-12";
-      const puzzleDate = "2020-01-01"; // 5+ years ago
-
-      const shouldUpdate = shouldUpdateStreak(puzzleDate, today);
-
-      expect(shouldUpdate).toBe(false);
+      expect(decision).toEqual({ update: false, reason: "archive" });
     });
   });
 
-  describe("Edge Cases", () => {
-    it("should NOT update streak for tomorrow's puzzle (future date - shouldn't exist)", () => {
-      const today = "2025-10-12";
-      const puzzleDate = "2025-10-13"; // Tomorrow (shouldn't be possible)
+  describe("Never-Rewind Guard", () => {
+    it("does NOT update streak when the puzzle is older than the last completion", () => {
+      // UTC+14 player completed 10-13's puzzle, then replays 10-12's.
+      const decision = shouldUpdateStreakForPuzzle("2025-10-12", "2025-10-13", "2025-10-12");
 
-      const shouldUpdate = shouldUpdateStreak(puzzleDate, today);
-
-      expect(shouldUpdate).toBe(false);
+      expect(decision).toEqual({ update: false, reason: "older-than-last" });
     });
 
-    it("should handle month boundary correctly", () => {
-      const today = "2025-11-01";
-      const yesterdayPuzzle = "2025-10-31";
+    it("does NOT let an in-envelope loss on an older day reset a newer streak", () => {
+      const decision = shouldUpdateStreakForPuzzle("2025-10-11", "2025-10-12", "2025-10-12");
 
-      // Yesterday's puzzle (different month) should NOT update streak
-      expect(shouldUpdateStreak(yesterdayPuzzle, today)).toBe(false);
-
-      // Today's puzzle should update streak
-      expect(shouldUpdateStreak(today, today)).toBe(true);
-    });
-
-    it("should handle year boundary correctly", () => {
-      const today = "2026-01-01";
-      const lastYearPuzzle = "2025-12-31";
-
-      // Last year's puzzle should NOT update streak
-      expect(shouldUpdateStreak(lastYearPuzzle, today)).toBe(false);
-
-      // Today's puzzle should update streak
-      expect(shouldUpdateStreak(today, today)).toBe(true);
+      expect(decision).toEqual({ update: false, reason: "older-than-last" });
     });
   });
 
   describe("Real-World Gaming Scenarios (Prevented)", () => {
-    it("EXPLOIT PREVENTION: Cannot keep streak alive with archive puzzle", () => {
-      // Scenario: User's streak expires (last played Oct 10, today is Oct 12)
-      // User tries to play Oct 11 puzzle to fill the gap
-      // Expected: Archive play does NOT affect streak
-
-      const today = "2025-10-12";
-      const archivePuzzleDate = "2025-10-11"; // Trying to "fill the gap"
-
-      const shouldUpdate = shouldUpdateStreak(archivePuzzleDate, today);
-
-      expect(shouldUpdate).toBe(false);
-      // Streak remains broken - user must play TODAY's puzzle
-    });
-
     it("EXPLOIT PREVENTION: Cannot revive dead streak with old puzzles", () => {
-      // Scenario: User's streak reset to 0 weeks ago
-      // User goes back and completes many old puzzles
-      // Expected: Archive plays do NOT revive streak
-
+      // User's streak reset weeks ago; completing many old puzzles must not
+      // revive it. Only dates inside the envelope can count.
       const today = "2025-10-12";
-      const oldPuzzles = ["2025-10-11", "2025-10-10", "2025-10-09", "2025-10-08", "2025-10-07"];
+      const oldPuzzles = ["2025-10-09", "2025-10-08", "2025-10-07", "2025-09-01"];
 
-      // None of these should update streak
       oldPuzzles.forEach((puzzleDate) => {
-        expect(shouldUpdateStreak(puzzleDate, today)).toBe(false);
+        expect(shouldUpdateStreakForPuzzle(puzzleDate, "2025-09-30", today)).toEqual({
+          update: false,
+          reason: "archive",
+        });
       });
-
-      // Only today's puzzle can start a new streak
-      expect(shouldUpdateStreak(today, today)).toBe(true);
     });
 
-    it("EXPLOIT PREVENTION: Cannot avoid today's puzzle to preserve streak", () => {
-      // Scenario: Today's puzzle is very hard
-      // User plays archive puzzles instead to "maintain engagement"
-      // Expected: Streak WILL break if today's puzzle isn't played
-
+    it("EXPLOIT PREVENTION: Cannot avoid today's puzzle with archive plays", () => {
+      // Playing easy archive puzzles does not extend the streak deadline.
       const today = "2025-10-12";
-      const safeArchivePuzzles = [
-        "2025-10-05", // Easy puzzle from last week
-        "2025-09-20", // Easy puzzle from last month
-      ];
+      const safeArchivePuzzles = ["2025-10-05", "2025-09-20"];
 
-      // Playing archive puzzles doesn't extend deadline
       safeArchivePuzzles.forEach((puzzleDate) => {
-        expect(shouldUpdateStreak(puzzleDate, today)).toBe(false);
+        expect(shouldUpdateStreakForPuzzle(puzzleDate, "2025-10-11", today).update).toBe(false);
       });
 
-      // User MUST play today's puzzle to maintain streak
-      expect(shouldUpdateStreak(today, today)).toBe(true);
+      // Today's puzzle is what keeps the streak alive.
+      expect(shouldUpdateStreakForPuzzle(today, "2025-10-11", today)).toEqual({
+        update: true,
+        reason: "daily",
+      });
+    });
+
+    it("EDGE OF ENVELOPE: playing one day late is indistinguishable from an honest timezone", () => {
+      // A puzzle dated UTC-yesterday can be a legitimate local-today play
+      // (US evening), so it is admitted; anything older is not.
+      const today = "2025-10-12";
+
+      expect(shouldUpdateStreakForPuzzle("2025-10-11", "2025-10-10", today).update).toBe(true);
+      expect(shouldUpdateStreakForPuzzle("2025-10-10", "2025-10-09", today).update).toBe(false);
     });
   });
 
-  describe("Integration with Streak Calculation", () => {
-    /**
-     * Simulate combined guard + streak calculation logic
-     */
-    it("should preserve existing streak logic for daily puzzles", () => {
-      const today = "2025-10-12";
-      const dailyPuzzleDate = "2025-10-12";
-
-      // Guard passes for daily puzzle
-      const shouldUpdate = shouldUpdateStreak(dailyPuzzleDate, today);
-      expect(shouldUpdate).toBe(true);
-
-      // Streak calculation proceeds normally
-      // (calculateStreakUpdate handles same-day replay, consecutive days, gaps, etc.)
+  describe("Month/Year Boundaries", () => {
+    it("handles month boundary inside the envelope", () => {
+      expect(shouldUpdateStreakForPuzzle("2025-10-31", "2025-10-30", "2025-11-01").update).toBe(
+        true,
+      );
     });
 
-    it("should short-circuit before streak calculation for archive puzzles", () => {
-      const today = "2025-10-12";
-      const archivePuzzleDate = "2025-10-05";
+    it("handles year boundary inside the envelope", () => {
+      expect(shouldUpdateStreakForPuzzle("2025-12-31", "2025-12-30", "2026-01-01").update).toBe(
+        true,
+      );
+    });
 
-      // Guard fails for archive puzzle
-      const shouldUpdate = shouldUpdateStreak(archivePuzzleDate, today);
-      expect(shouldUpdate).toBe(false);
-
-      // Streak calculation is never called (early return)
-      // No database writes occur
+    it("rejects two-day gaps across year boundary", () => {
+      expect(shouldUpdateStreakForPuzzle("2025-12-30", "2025-12-29", "2026-01-01")).toEqual({
+        update: false,
+        reason: "archive",
+      });
     });
   });
 });

--- a/convex/__tests__/streakDayBoundary.convex.test.ts
+++ b/convex/__tests__/streakDayBoundary.convex.test.ts
@@ -1,0 +1,168 @@
+import { convexTest } from "convex-test";
+import { anyApi } from "convex/server";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import schema from "../schema";
+import { modules } from "../test.setup";
+import type { Id } from "../_generated/dataModel";
+
+// Type assertion for path-based API access (works at runtime, not type-checked)
+const apiRef = anyApi as any;
+const puzzlesMutations = apiRef["puzzles/mutations"];
+
+/**
+ * Streak Day-Boundary Tests (canonical local-day semantics)
+ *
+ * Chrondle's canonical "today" is the PLAYER'S local calendar day: game pages
+ * resolve puzzles by the client's local date (src/lib/time/dailyDate.ts), so
+ * the puzzle a player completes in the evening (after 00:00 UTC but before
+ * local midnight) carries a date one day BEHIND the server's UTC date.
+ *
+ * Streak rules under these semantics:
+ * - The puzzle's own date is the streak day marker (puzzle dates are the
+ *   canonical day sequence).
+ * - A puzzle counts as "daily" if its date is within one day of the server's
+ *   UTC date — the timezone envelope (UTC-12..UTC+14). Anything older is
+ *   archive and never touches the streak.
+ * - Playing an older-dated puzzle after a newer one never rewinds or resets
+ *   the streak.
+ */
+describe("streak day boundaries (local-day semantics)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function seed(
+    t: ReturnType<typeof convexTest>,
+    clerkId: string,
+    user: { currentStreak: number; longestStreak: number; lastCompletedDate?: string },
+    puzzleDate: string,
+  ): Promise<{ puzzleId: Id<"puzzles">; userId: Id<"users"> }> {
+    let puzzleId: Id<"puzzles">;
+    let userId: Id<"users">;
+    await t.run(async (ctx) => {
+      userId = await ctx.db.insert("users", {
+        clerkId,
+        email: `${clerkId}@test.com`,
+        currentStreak: user.currentStreak,
+        longestStreak: user.longestStreak,
+        lastCompletedDate: user.lastCompletedDate,
+        totalPlays: 0,
+        perfectGames: 0,
+        updatedAt: Date.now(),
+      });
+      puzzleId = await ctx.db.insert("puzzles", {
+        puzzleNumber: 100,
+        date: puzzleDate,
+        targetYear: 1969,
+        events: ["E1", "E2", "E3", "E4", "E5", "E6"],
+        playCount: 0,
+        avgGuesses: 0,
+        updatedAt: Date.now(),
+      });
+    });
+    return { puzzleId: puzzleId!, userId: userId! };
+  }
+
+  async function getUser(t: ReturnType<typeof convexTest>, userId: Id<"users">) {
+    return await t.run(async (ctx) => {
+      return await ctx.db.get(userId);
+    });
+  }
+
+  it("continues the streak when completing today's LOCAL puzzle after 00:00 UTC", async () => {
+    // 2026-07-07T04:00Z = evening of 2026-07-06 in US timezones.
+    // The player's local "today" (and thus the puzzle they play) is 07-06.
+    vi.setSystemTime(new Date("2026-07-07T04:00:00.000Z"));
+
+    const t = convexTest(schema, modules);
+    const clerkId = "boundary_evening";
+    const { puzzleId, userId } = await seed(
+      t,
+      clerkId,
+      { currentStreak: 3, longestStreak: 5, lastCompletedDate: "2026-07-05" },
+      "2026-07-06",
+    );
+
+    await t.withIdentity({ subject: clerkId }).mutation(puzzlesMutations.submitGuess, {
+      puzzleId,
+      guess: 1969,
+    });
+
+    const user = await getUser(t, userId);
+    expect(user?.currentStreak).toBe(4);
+    expect(user?.lastCompletedDate).toBe("2026-07-06");
+  });
+
+  it("continues the streak for players ahead of UTC (puzzle date = UTC tomorrow)", async () => {
+    // 2026-07-06T22:00Z = morning of 2026-07-07 in UTC+14 (Kiritimati).
+    vi.setSystemTime(new Date("2026-07-06T22:00:00.000Z"));
+
+    const t = convexTest(schema, modules);
+    const clerkId = "boundary_ahead";
+    const { puzzleId, userId } = await seed(
+      t,
+      clerkId,
+      { currentStreak: 1, longestStreak: 1, lastCompletedDate: "2026-07-06" },
+      "2026-07-07",
+    );
+
+    await t.withIdentity({ subject: clerkId }).mutation(puzzlesMutations.submitGuess, {
+      puzzleId,
+      guess: 1969,
+    });
+
+    const user = await getUser(t, userId);
+    expect(user?.currentStreak).toBe(2);
+    expect(user?.lastCompletedDate).toBe("2026-07-07");
+  });
+
+  it("does NOT update the streak for an archive puzzle (2+ days old)", async () => {
+    vi.setSystemTime(new Date("2026-07-07T04:00:00.000Z"));
+
+    const t = convexTest(schema, modules);
+    const clerkId = "boundary_archive";
+    const { puzzleId, userId } = await seed(
+      t,
+      clerkId,
+      { currentStreak: 3, longestStreak: 5, lastCompletedDate: "2026-07-04" },
+      "2026-07-05", // two days behind UTC today: outside the timezone envelope
+    );
+
+    await t.withIdentity({ subject: clerkId }).mutation(puzzlesMutations.submitGuess, {
+      puzzleId,
+      guess: 1969,
+    });
+
+    const user = await getUser(t, userId);
+    expect(user?.currentStreak).toBe(3);
+    expect(user?.lastCompletedDate).toBe("2026-07-04");
+  });
+
+  it("never rewinds the streak when playing an older-dated puzzle after a newer one", async () => {
+    // Player already completed 07-07 (UTC+14 morning), then plays 07-06's
+    // puzzle. Within the timezone envelope, but must not reset the streak.
+    vi.setSystemTime(new Date("2026-07-06T22:00:00.000Z"));
+
+    const t = convexTest(schema, modules);
+    const clerkId = "boundary_rewind";
+    const { puzzleId, userId } = await seed(
+      t,
+      clerkId,
+      { currentStreak: 7, longestStreak: 7, lastCompletedDate: "2026-07-07" },
+      "2026-07-06",
+    );
+
+    await t.withIdentity({ subject: clerkId }).mutation(puzzlesMutations.submitGuess, {
+      puzzleId,
+      guess: 1969,
+    });
+
+    const user = await getUser(t, userId);
+    expect(user?.currentStreak).toBe(7);
+    expect(user?.lastCompletedDate).toBe("2026-07-07");
+  });
+});

--- a/convex/lib/__tests__/puzzleType.test.ts
+++ b/convex/lib/__tests__/puzzleType.test.ts
@@ -21,17 +21,38 @@ describe("classifyPuzzle", () => {
       expect(result).toEqual({ type: "daily", date: "2025-10-16" });
     });
 
-    it("classifies puzzle as archive when date is in the past", () => {
+    it("classifies puzzle as daily when date is yesterday (timezone envelope)", () => {
+      // The canonical "today" is the PLAYER'S local day: after 00:00 UTC a
+      // player's daily puzzle date is one day behind the server's UTC date.
       const result = classifyPuzzle("2025-10-15", "2025-10-16");
 
-      expect(result).toEqual({ type: "archive", date: "2025-10-15" });
+      expect(result).toEqual({ type: "daily", date: "2025-10-15" });
     });
 
-    it("classifies puzzle as archive when date is in the future", () => {
-      // Edge case: future-dated puzzles are also "archive" (not daily)
+    it("classifies puzzle as daily when date is tomorrow (timezone envelope)", () => {
+      // Players ahead of UTC (up to UTC+14) legitimately play a puzzle dated
+      // one day ahead of the server's UTC date.
       const result = classifyPuzzle("2025-10-17", "2025-10-16");
 
-      expect(result).toEqual({ type: "archive", date: "2025-10-17" });
+      expect(result).toEqual({ type: "daily", date: "2025-10-17" });
+    });
+
+    it("classifies puzzle as archive when date is two days in the past", () => {
+      const result = classifyPuzzle("2025-10-14", "2025-10-16");
+
+      expect(result).toEqual({ type: "archive", date: "2025-10-14" });
+    });
+
+    it("classifies puzzle as archive when date is two days in the future", () => {
+      const result = classifyPuzzle("2025-10-18", "2025-10-16");
+
+      expect(result).toEqual({ type: "archive", date: "2025-10-18" });
+    });
+
+    it("classifies puzzle as archive when date is far in the past", () => {
+      const result = classifyPuzzle("2025-09-16", "2025-10-16");
+
+      expect(result).toEqual({ type: "archive", date: "2025-09-16" });
     });
   });
 
@@ -45,20 +66,26 @@ describe("classifyPuzzle", () => {
       expect(result).toEqual({ type: "daily", date: "2025-10-16" });
     });
 
-    it("classifies as archive when puzzle date is yesterday", () => {
+    it("classifies as archive when puzzle date is two days before UTC today", () => {
       vi.setSystemTime(new Date("2025-10-16T12:00:00.000Z"));
 
-      const result = classifyPuzzle("2025-10-15");
+      const result = classifyPuzzle("2025-10-14");
 
-      expect(result).toEqual({ type: "archive", date: "2025-10-15" });
+      expect(result).toEqual({ type: "archive", date: "2025-10-14" });
     });
   });
 
   describe("edge cases", () => {
-    it("handles year boundary correctly", () => {
+    it("handles year boundary correctly (yesterday across new year is still daily)", () => {
       const result = classifyPuzzle("2024-12-31", "2025-01-01");
 
-      expect(result).toEqual({ type: "archive", date: "2024-12-31" });
+      expect(result).toEqual({ type: "daily", date: "2024-12-31" });
+    });
+
+    it("handles year boundary correctly (two days across new year is archive)", () => {
+      const result = classifyPuzzle("2024-12-30", "2025-01-01");
+
+      expect(result).toEqual({ type: "archive", date: "2024-12-30" });
     });
 
     it("handles leap year date", () => {
@@ -118,7 +145,7 @@ describe("classifyPuzzle + type guards integration", () => {
   });
 
   it("archive puzzle passes isArchivePuzzle guard", () => {
-    const classification = classifyPuzzle("2025-10-15", "2025-10-16");
+    const classification = classifyPuzzle("2025-10-13", "2025-10-16");
 
     expect(isDailyPuzzle(classification)).toBe(false);
     expect(isArchivePuzzle(classification)).toBe(true);

--- a/convex/lib/puzzleType.ts
+++ b/convex/lib/puzzleType.ts
@@ -6,11 +6,18 @@
  * This module provides type-safe classification of puzzles as "daily" or "archive"
  * to enforce the business rule that only today's daily puzzle should affect user streaks.
  *
+ * DAY SEMANTICS: Chrondle's canonical "today" is the PLAYER'S local calendar
+ * day (see src/lib/time/dailyDate.ts). Clients resolve their daily puzzle by
+ * local date, so the daily puzzle a player legitimately completes can carry a
+ * date up to one day away from the server's UTC date (timezone envelope
+ * UTC-12..UTC+14). A puzzle is therefore classified "daily" when its date is
+ * within one day of the server's UTC date; anything further out is archive.
+ *
  * Implementation: Classification is derived from puzzle date vs. current date,
  * ensuring a single source of truth with no possibility of type/date mismatch.
  */
 
-import { getUTCDateString } from "./streakCalculation";
+import { dayDifference, getUTCDateString } from "./streakCalculation";
 
 /**
  * Discriminated union for puzzle classification
@@ -49,7 +56,11 @@ export type PuzzleType = { type: "daily"; date: string } | { type: "archive"; da
 export function classifyPuzzle(puzzleDate: string, currentDate?: string): PuzzleType {
   const today = currentDate ?? getUTCDateString();
 
-  if (puzzleDate === today) {
+  // Daily = within the timezone envelope of the server's UTC day. A player's
+  // local "today" (the canonical day; see module doc) is always within one
+  // day of UTC, so |diff| <= 1 admits every legitimate daily play and rejects
+  // all genuinely historical puzzles.
+  if (Math.abs(dayDifference(today, puzzleDate)) <= 1) {
     return { type: "daily", date: puzzleDate };
   } else {
     return { type: "archive", date: puzzleDate };

--- a/convex/lib/streakCalculation.ts
+++ b/convex/lib/streakCalculation.ts
@@ -128,6 +128,33 @@ function isValidDateString(dateString: string): boolean {
 }
 
 /**
+ * Signed difference in whole days between two ISO date strings (b - a)
+ *
+ * @param a - First date (ISO string YYYY-MM-DD)
+ * @param b - Second date (ISO string YYYY-MM-DD)
+ * @returns Number of days from a to b (positive if b is after a)
+ *
+ * @throws Error if date strings are invalid
+ *
+ * @example
+ * dayDifference("2025-10-07", "2025-10-08") // 1
+ * dayDifference("2025-10-08", "2025-10-07") // -1
+ * dayDifference("2025-10-08", "2025-10-08") // 0
+ */
+export function dayDifference(a: string, b: string): number {
+  if (!isValidDateString(a)) {
+    throw new Error(`Invalid first date: ${a}`);
+  }
+  if (!isValidDateString(b)) {
+    throw new Error(`Invalid second date: ${b}`);
+  }
+
+  const first = new Date(a + "T00:00:00.000Z").getTime();
+  const second = new Date(b + "T00:00:00.000Z").getTime();
+  return Math.round((second - first) / 86_400_000);
+}
+
+/**
  * Check if two dates are consecutive (second date is exactly one day after first)
  *
  * @param firstDate - Earlier date (ISO string YYYY-MM-DD)

--- a/convex/lib/streakHelpers.ts
+++ b/convex/lib/streakHelpers.ts
@@ -1,6 +1,6 @@
 import { DatabaseWriter } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
-import { calculateStreakUpdate, applyStreakUpdate, getUTCDateString } from "./streakCalculation";
+import { calculateStreakUpdate, applyStreakUpdate, dayDifference } from "./streakCalculation";
 import { classifyPuzzle, isDailyPuzzle } from "./puzzleType";
 
 /**
@@ -12,9 +12,48 @@ import { classifyPuzzle, isDailyPuzzle } from "./puzzleType";
  * CRITICAL BUSINESS RULE: Only updates streak for TODAY'S daily puzzle.
  * Archive/historical puzzle plays MUST NOT affect daily streak mechanics.
  *
+ * DAY SEMANTICS: The puzzle's own date is the streak day marker. Chrondle's
+ * canonical "today" is the player's local calendar day (the puzzle they play
+ * is resolved by local date; see src/lib/time/dailyDate.ts), so the server
+ * clock must never define the streak boundary — after 00:00 UTC a player's
+ * daily puzzle date is one day behind the server's UTC date. Consecutive
+ * puzzle dates are consecutive days by construction.
+ *
  * Dependencies:
  * - streakCalculation: Pure functions for streak state management
  */
+
+/**
+ * Decide whether a puzzle play may touch the user's streak
+ *
+ * Pure decision function (exported for tests):
+ * - "archive": puzzle date outside the timezone envelope (see puzzleType.ts)
+ * - "older-than-last": puzzle dated before the user's last completion —
+ *   playing backwards must never rewind or reset a streak
+ * - "daily": streak update proceeds (calculateStreakUpdate owns the rest:
+ *   same-day replay, consecutive-day increment, gap restart, loss reset)
+ *
+ * @param puzzleDate - ISO date (YYYY-MM-DD) of the puzzle being played
+ * @param lastCompletedDate - User's last completion date or null
+ * @param currentDate - Optional server date override (defaults to UTC now)
+ */
+export function shouldUpdateStreakForPuzzle(
+  puzzleDate: string,
+  lastCompletedDate: string | null,
+  currentDate?: string,
+): { update: boolean; reason: "daily" | "archive" | "older-than-last" } {
+  const classification = classifyPuzzle(puzzleDate, currentDate);
+
+  if (!isDailyPuzzle(classification)) {
+    return { update: false, reason: "archive" };
+  }
+
+  if (lastCompletedDate && dayDifference(puzzleDate, lastCompletedDate) > 0) {
+    return { update: false, reason: "older-than-last" };
+  }
+
+  return { update: true, reason: "daily" };
+}
 
 /**
  * Update user streak after completing a puzzle
@@ -39,32 +78,31 @@ export async function updateUserStreak(
     throw new Error("User not found");
   }
 
-  // CRITICAL: Capture UTC date ONCE to prevent midnight rollover race condition
-  // between puzzle classification and streak calculation. If midnight occurs
-  // between these calls, classification might use yesterday's date while
-  // streak calculation uses today's date, causing incorrect streak updates.
-  const today = getUTCDateString();
+  // CRITICAL: Only update streak for a daily puzzle (puzzle date within the
+  // timezone envelope of the server's UTC day; see puzzleType.ts), and never
+  // rewind: a play of an older-dated puzzle after a newer completion (e.g. a
+  // UTC+14 player finishing tomorrow's puzzle, then replaying yesterday's
+  // inside the envelope) must not reset or rewind the streak.
+  const decision = shouldUpdateStreakForPuzzle(puzzleDate, user.lastCompletedDate || null);
 
-  // CRITICAL: Only update streak for today's daily puzzle
-  // Archive/historical puzzle plays should NOT affect daily streak
-  // Type-safe classification ensures this rule is enforced at compile time
-  // Pass 'today' to ensure classification and calculation use same date reference
-  const classification = classifyPuzzle(puzzleDate, today);
-
-  if (!isDailyPuzzle(classification)) {
-    console.warn("[updateUserStreak] Skipping streak update for archive puzzle:", {
-      puzzleType: classification.type,
-      puzzleDate: classification.date,
+  if (!decision.update) {
+    console.warn("[updateUserStreak] Skipping streak update:", {
+      reason: decision.reason,
+      puzzleDate,
+      lastCompletedDate: user.lastCompletedDate,
       userId,
     });
-    return; // No streak update for archive puzzles
+    return;
   }
 
-  // Calculate streak update using explicit discriminated union
+  // Calculate streak update using explicit discriminated union.
+  // The PUZZLE date — not the server clock — is the day marker: it is the
+  // player's local "today" for daily play, and consecutive puzzle dates are
+  // consecutive days by construction.
   const update = calculateStreakUpdate(
     user.lastCompletedDate || null,
     user.currentStreak,
-    today,
+    puzzleDate,
     hasWon,
   );
 

--- a/convex/orderPuzzles/queries.ts
+++ b/convex/orderPuzzles/queries.ts
@@ -7,7 +7,7 @@ import { query } from "../_generated/server";
  *
  * Exports:
  * - getOrderPuzzleByDate: Get Order puzzle for specific date (local date support)
- * - getDailyOrderPuzzle: Get today's Order puzzle (UTC, backward compat)
+ * - getDailyOrderPuzzle: QUARANTINED (UTC-day; stale-client compat only)
  * - getOrderPuzzleByNumber: Get Order puzzle by sequential number
  * - getArchiveOrderPuzzles: Get paginated archive Order puzzles
  */
@@ -32,10 +32,18 @@ export const getOrderPuzzleByDate = query({
 });
 
 /**
- * Get today's Order puzzle using UTC date
+ * QUARANTINED — DO NOT CONSUME FROM UI CODE.
  *
- * Wrapper for backward compatibility.
- * For new code, prefer getOrderPuzzleByDate with client's local date.
+ * Resolves "today" on the SERVER'S UTC clock, which disagrees with Chrondle's
+ * canonical day (the player's local calendar day — see
+ * src/lib/time/dailyDate.ts) for part of every day. All app consumers were
+ * removed (chrondle-ux-daily-identity) and an ESLint no-restricted-syntax
+ * rule blocks reintroduction in src/.
+ *
+ * Kept ONLY so stale client bundles deployed before the fix don't hard-error;
+ * safe to delete after a release window.
+ *
+ * @deprecated Use getOrderPuzzleByDate with the client's local date.
  */
 export const getDailyOrderPuzzle = query({
   handler: async (ctx) => {

--- a/convex/puzzles/queries.ts
+++ b/convex/puzzles/queries.ts
@@ -8,8 +8,8 @@ import { query } from "../_generated/server";
  * Deep Module Value: Hides database query complexity behind clean API
  *
  * Exports:
- * - getDailyPuzzle: Get today's puzzle (UTC)
- * - getPuzzleByDate: Get puzzle for specific date (local date support)
+ * - getDailyPuzzle: QUARANTINED (UTC-day; stale-client compat only — see below)
+ * - getPuzzleByDate: Get puzzle for specific date (canonical: client's local date)
  * - getPuzzleById: Get puzzle by Convex ID
  * - getPuzzleByNumber: Get puzzle by sequential number
  * - getArchivePuzzles: Get paginated archive puzzles
@@ -39,12 +39,20 @@ export const getPuzzleByDate = query({
 });
 
 /**
- * Get today's puzzle using UTC date
+ * QUARANTINED — DO NOT CONSUME FROM UI CODE.
  *
- * Wrapper around getPuzzleByDate for backward compatibility.
- * For new code, prefer getPuzzleByDate with client's local date.
+ * Resolves "today" on the SERVER'S UTC clock, which disagrees with Chrondle's
+ * canonical day (the player's local calendar day — see
+ * src/lib/time/dailyDate.ts) for part of every day. This is the query that
+ * made the homepage advertise tomorrow's puzzle while game pages played
+ * today's. All app consumers were removed (chrondle-ux-daily-identity) and an
+ * ESLint no-restricted-syntax rule blocks reintroduction in src/.
  *
- * @returns Today's puzzle or null if not yet generated
+ * Kept ONLY so stale client bundles deployed before the fix don't hard-error;
+ * safe to delete after a release window.
+ *
+ * @deprecated Use getPuzzleByDate with the client's local date.
+ * @returns Puzzle for the server's UTC date or null
  */
 export const getDailyPuzzle = query({
   handler: async (ctx) => {

--- a/e2e/daily-identity.spec.ts
+++ b/e2e/daily-identity.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Daily Identity E2E — one "today" everywhere
+ *
+ * Chrondle's canonical "today" is the player's LOCAL calendar day
+ * (src/lib/time/dailyDate.ts). These tests freeze the browser clock inside
+ * the historical bug window — AFTER 00:00 UTC but BEFORE local midnight in a
+ * negative-offset timezone (America/Los_Angeles) — where the homepage used to
+ * advertise tomorrow's (UTC) puzzle number while the game page played
+ * today's (local) puzzle.
+ *
+ * Invariant under test: the homepage mode-card puzzle number equals the
+ * game-page header number for the same mode, at any wall-clock time.
+ *
+ * Tagged @daily-identity for targeted runs:
+ *   bunx playwright test e2e/daily-identity.spec.ts --project=chromium
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+// Compute a frozen instant that is "YESTERDAY evening" in Los Angeles (the
+// most recent LA date guaranteed to have a generated puzzle), at 20:00 LA
+// time. Freezing to a date that differs from the machine's real date makes
+// BOTH historical failure modes visible at any real run time:
+// - a client-side UTC-day derivation would compute frozen-UTC = D+1 ≠ D;
+// - a server-clock query (like the quarantined getDailyPuzzle) would resolve
+//   the server's REAL date ≠ D (page.clock cannot freeze the server, so
+//   freezing to "real today" would let that regression pass undetected).
+function frozenEveningInLA(): { instant: Date; laDate: string } {
+  const laYesterday = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Los_Angeles",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(Date.now() - 24 * 60 * 60 * 1000)); // YYYY-MM-DD
+
+  // 20:00 PDT (-07:00). During PST this instant is 19:00 LA time — either
+  // way the frozen browser-local date is laYesterday while the frozen
+  // browser-UTC date is laYesterday+1 (the divergence window).
+  const instant = new Date(`${laYesterday}T20:00:00-07:00`);
+  return { instant, laDate: laYesterday };
+}
+
+async function readGalleryPuzzleNumber(page: Page, mode: "Classic" | "Order"): Promise<number> {
+  const card = page.getByRole("button", { name: new RegExp(mode, "i") });
+  await expect(card).toBeVisible();
+  // Mode-card label renders "Puzzle #N" once the daily puzzle resolves.
+  await expect(card.getByText(/Puzzle #\d+/)).toBeVisible({ timeout: 20000 });
+  const label = await card.getByText(/Puzzle #\d+/).textContent();
+  const match = label?.match(/#(\d+)/);
+  expect(match, `gallery ${mode} card should show a puzzle number`).toBeTruthy();
+  return Number(match![1]);
+}
+
+async function readHeaderPuzzleNumber(page: Page): Promise<number> {
+  // AppHeader renders the daily puzzle number as "#N" (optionally followed by
+  // the puzzle date) inside the <header> landmark.
+  const header = page.locator("header").first();
+  await expect(header.getByText(/#\d+/)).toBeVisible({ timeout: 30000 });
+  const text = await header.textContent();
+  const match = text?.match(/#(\d+)/);
+  expect(match, "game header should show a puzzle number").toBeTruthy();
+  return Number(match![1]);
+}
+
+test.describe("Daily identity @daily-identity", () => {
+  test.use({ timezoneId: "America/Los_Angeles" });
+
+  test("homepage Classic number matches the classic game header after 00:00 UTC", async ({
+    page,
+  }) => {
+    const { instant } = frozenEveningInLA();
+    await page.clock.setFixedTime(instant);
+
+    await page.goto("/");
+    const galleryNumber = await readGalleryPuzzleNumber(page, "Classic");
+
+    await page.getByRole("button", { name: /classic/i }).click();
+    await page.waitForURL(/\/classic/);
+    const headerNumber = await readHeaderPuzzleNumber(page);
+
+    expect(headerNumber).toBe(galleryNumber);
+  });
+
+  test("homepage Order number matches the order game header after 00:00 UTC", async ({ page }) => {
+    const { instant } = frozenEveningInLA();
+    await page.clock.setFixedTime(instant);
+
+    await page.goto("/");
+    const galleryNumber = await readGalleryPuzzleNumber(page, "Order");
+
+    await page.getByRole("button", { name: /order/i }).click();
+    await page.waitForURL(/\/order/);
+    const headerNumber = await readHeaderPuzzleNumber(page);
+
+    expect(headerNumber).toBe(galleryNumber);
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,12 +23,12 @@ const eslintConfig = [
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
-          "argsIgnorePattern": "^_",
-          "varsIgnorePattern": "^_",
-          "destructuredArrayIgnorePattern": "^_"
-        }
-      ]
-    }
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
+    },
   },
   // Next.js ignores
   ignoresConfig,
@@ -74,9 +74,10 @@ const eslintConfig = [
       "no-restricted-syntax": [
         "error",
         {
-          "selector": "Literal[value=/\\b(text|bg|border)-(ink|parchment)-\\d+\\b/]",
-          "message": "Do not use primitive tokens (text-ink-*, bg-parchment-*, etc). Use semantic tokens (text-primary, bg-surface-elevated, etc) from globals.css instead. See DESIGN_SYSTEM.md for token reference."
-        }
+          selector: "Literal[value=/\\b(text|bg|border)-(ink|parchment)-\\d+\\b/]",
+          message:
+            "Do not use primitive tokens (text-ink-*, bg-parchment-*, etc). Use semantic tokens (text-primary, bg-surface-elevated, etc) from globals.css instead. See DESIGN_SYSTEM.md for token reference.",
+        },
       ],
       // New React Compiler rules in Next.js 16 - demote to warnings for incremental adoption
       "react-hooks/refs": "warn",
@@ -91,22 +92,51 @@ const eslintConfig = [
       "react-hooks/globals": "warn",
       "react-hooks/error-boundaries": "warn",
       "react-hooks/config": "warn",
-      "react-hooks/gating": "warn"
-    }
+      "react-hooks/gating": "warn",
+    },
+  },
+  {
+    // App code must never resolve "today" on the server's UTC clock.
+    // Canonical day semantics: the player's local calendar day
+    // (src/lib/time/dailyDate.ts). The quarantined UTC-day Convex queries are
+    // kept only for stale client bundles (see convex/puzzles/queries.ts).
+    // NOTE: this block overrides "no-restricted-syntax" for src/**, so the
+    // global primitive-token selector is repeated here.
+    files: ["src/**/*.ts", "src/**/*.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "Literal[value=/\\b(text|bg|border)-(ink|parchment)-\\d+\\b/]",
+          message:
+            "Do not use primitive tokens (text-ink-*, bg-parchment-*, etc). Use semantic tokens (text-primary, bg-surface-elevated, etc) from globals.css instead. See DESIGN_SYSTEM.md for token reference.",
+        },
+        {
+          selector: "MemberExpression[property.name='getDailyPuzzle']",
+          message:
+            "getDailyPuzzle resolves 'today' on the server's UTC clock and is quarantined. Use getPuzzleByDate with the client's local date (useTodaysPuzzle / src/lib/time/dailyDate.ts).",
+        },
+        {
+          selector: "MemberExpression[property.name='getDailyOrderPuzzle']",
+          message:
+            "getDailyOrderPuzzle resolves 'today' on the server's UTC clock and is quarantined. Use getOrderPuzzleByDate with the client's local date (useTodaysOrderPuzzle / src/lib/time/dailyDate.ts).",
+        },
+      ],
+    },
   },
   {
     // Allow console usage in logger.ts itself (where logger is implemented)
     files: ["src/lib/logger.ts"],
     rules: {
-      "no-console": "off"
-    }
+      "no-console": "off",
+    },
   },
   {
     // Allow console usage in scripts (JS/MJS/TS files)
     files: ["scripts/**/*.js", "scripts/**/*.mjs", "scripts/**/*.ts"],
     rules: {
-      "no-console": "off"
-    }
+      "no-console": "off",
+    },
   },
   {
     // Convex files (Node.js context, not browser) - exclude test files
@@ -119,12 +149,12 @@ const eslintConfig = [
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
-          "argsIgnorePattern": "^_",
-          "varsIgnorePattern": "^_",
-          "destructuredArrayIgnorePattern": "^_"
-        }
-      ]
-    }
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
+    },
   },
   {
     // All test files - relax rules (must come after convex to override)
@@ -134,9 +164,9 @@ const eslintConfig = [
       ...tsConfig.rules,
       "no-console": "off",
       "@typescript-eslint/no-require-imports": "off",
-      "@typescript-eslint/no-unused-vars": "warn"
-    }
-  }
+      "@typescript-eslint/no-unused-vars": "warn",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/app/(app)/order/page.test.tsx
+++ b/src/app/(app)/order/page.test.tsx
@@ -14,7 +14,7 @@ vi.mock("convex/nextjs", () => ({
 vi.mock("@/lib/convexServer", () => ({
   api: {
     orderPuzzles: {
-      getDailyOrderPuzzle: "order-query",
+      getOrderPuzzleByDate: "order-by-date-query",
     },
   },
 }));
@@ -56,6 +56,16 @@ describe("OrderPage", () => {
 
     expect(screen.getByTestId("order-game-island")).toHaveTextContent("loaded");
     expect(screen.queryByTestId("mode-unavailable-state")).not.toBeInTheDocument();
+  });
+
+  it("seeds the preload with an explicit date (never the implicit UTC-day query)", async () => {
+    preloadQueryMock.mockResolvedValueOnce({ preloaded: true });
+
+    render(await OrderPage());
+
+    expect(preloadQueryMock).toHaveBeenCalledWith("order-by-date-query", {
+      date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+    });
   });
 
   it("renders the unavailable state when preload returns null", async () => {

--- a/src/app/(app)/order/page.tsx
+++ b/src/app/(app)/order/page.tsx
@@ -8,12 +8,21 @@ import { OrderGameIsland } from "@/components/order/OrderGameIsland";
 import { LoadingShell } from "@/components/LoadingShell";
 import { logger } from "@/lib/logger";
 import { isBackendUnavailablePreloadError } from "@/lib/preloadQueryAvailability";
+import { getUTCDateString } from "@/lib/time/dailyDate";
 
 export default async function OrderPage() {
   let preloadedPuzzle = null;
 
   try {
-    preloadedPuzzle = await preloadQuery(api.orderPuzzles.getDailyOrderPuzzle);
+    // Best-effort SSR seed only: the server cannot know the player's local
+    // date, so it seeds with its own (UTC) date. The client hook
+    // (useTodaysOrderPuzzle) validates the seed against the player's LOCAL
+    // date — Chrondle's canonical "today", see src/lib/time/dailyDate.ts —
+    // and refetches when they differ. The seed never decides which puzzle is
+    // played.
+    preloadedPuzzle = await preloadQuery(api.orderPuzzles.getOrderPuzzleByDate, {
+      date: getUTCDateString(),
+    });
   } catch (error) {
     if (!isBackendUnavailablePreloadError(error)) {
       throw error;

--- a/src/components/GamesGallery.tsx
+++ b/src/components/GamesGallery.tsx
@@ -2,9 +2,9 @@
 
 import { useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { useQuery } from "convex/react";
 
-import { anyPublicApi } from "@/lib/convexAnyApi";
+import { useTodaysPuzzle } from "@/hooks/useTodaysPuzzle";
+import { useTodaysOrderPuzzle } from "@/hooks/useTodaysOrderPuzzle";
 import { setModePreferenceCookie, type ModeKey } from "@/lib/modePreference";
 import { MODES } from "@/lib/modes";
 import { cn } from "@/lib/utils";
@@ -46,8 +46,13 @@ const MODE_CARDS: ModeCardConfig[] = [
 
 export function GamesGallery() {
   const router = useRouter();
-  const classicPuzzle = useQuery(anyPublicApi.puzzles.getDailyPuzzle);
-  const orderPuzzle = useQuery(anyPublicApi.orderPuzzles.getDailyOrderPuzzle);
+  // ONE "today" everywhere: the gallery consumes the SAME local-date daily
+  // hooks as the game pages (canonical day semantics live in
+  // src/lib/time/dailyDate.ts), so the mode-card numbers always name the
+  // puzzle the player will actually play — including across the window after
+  // 00:00 UTC but before local midnight.
+  const { puzzle: classicPuzzle } = useTodaysPuzzle();
+  const { puzzle: orderPuzzle } = useTodaysOrderPuzzle();
 
   const handleSelect = useCallback(
     (mode: ModeKey, route: string) => {

--- a/src/components/__tests__/GamesGallery.test.tsx
+++ b/src/components/__tests__/GamesGallery.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { useQuery } from "convex/react";
+import { useTodaysPuzzle } from "@/hooks/useTodaysPuzzle";
+import { useTodaysOrderPuzzle } from "@/hooks/useTodaysOrderPuzzle";
 import { GamesGallery } from "../GamesGallery";
 
 // --- Mocks ---
@@ -26,8 +27,15 @@ vi.mock("motion/react", () => ({
   useReducedMotion: () => false,
 }));
 
-vi.mock("convex/react", () => ({
-  useQuery: vi.fn(),
+// The gallery must consume the SAME local-date daily hooks as the game pages
+// (src/hooks/useTodaysPuzzle.ts / useTodaysOrderPuzzle.ts) so the homepage can
+// never advertise a different puzzle than the one a player actually plays.
+vi.mock("@/hooks/useTodaysPuzzle", () => ({
+  useTodaysPuzzle: vi.fn(),
+}));
+
+vi.mock("@/hooks/useTodaysOrderPuzzle", () => ({
+  useTodaysOrderPuzzle: vi.fn(),
 }));
 
 vi.mock("@phosphor-icons/react", () => ({
@@ -38,12 +46,42 @@ vi.mock("@phosphor-icons/react", () => ({
   Sword: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="sword-icon" {...props} />,
 }));
 
+function mockClassic(puzzleNumber: number | null) {
+  vi.mocked(useTodaysPuzzle).mockReturnValue({
+    puzzle:
+      puzzleNumber === null
+        ? null
+        : ({ puzzleNumber, date: "2026-07-06" } as ReturnType<typeof useTodaysPuzzle>["puzzle"]),
+    isLoading: puzzleNumber === null,
+    error: null,
+    localDate: "2026-07-06",
+    revalidate: vi.fn(),
+  });
+}
+
+function mockOrder(puzzleNumber: number | null) {
+  vi.mocked(useTodaysOrderPuzzle).mockReturnValue({
+    puzzle:
+      puzzleNumber === null
+        ? null
+        : ({ puzzleNumber, date: "2026-07-06" } as ReturnType<
+            typeof useTodaysOrderPuzzle
+          >["puzzle"]),
+    isLoading: puzzleNumber === null,
+    error: null,
+    localDate: "2026-07-06",
+    usedPreload: false,
+    revalidate: vi.fn(),
+  });
+}
+
 describe("GamesGallery", () => {
   beforeEach(() => {
     mockPush.mockClear();
-    const mockUseQuery = vi.mocked(useQuery);
-    mockUseQuery.mockReset();
-    mockUseQuery.mockReturnValue({ puzzleNumber: 247 });
+    vi.mocked(useTodaysPuzzle).mockReset();
+    vi.mocked(useTodaysOrderPuzzle).mockReset();
+    mockClassic(328);
+    mockOrder(239);
   });
 
   afterEach(() => {
@@ -76,7 +114,6 @@ describe("GamesGallery", () => {
       expect(screen.getByText("Start a Run")).toBeInTheDocument();
 
       expect(screen.getAllByText("New")).toHaveLength(2);
-      expect(screen.getAllByText("Puzzle #247")).toHaveLength(2);
       expect(screen.getByText("Endless")).toBeInTheDocument();
     });
 
@@ -86,6 +123,30 @@ describe("GamesGallery", () => {
       expect(screen.getByTestId("crosshair-icon")).toBeInTheDocument();
       expect(screen.getByTestId("shuffle-icon")).toBeInTheDocument();
       expect(screen.getByTestId("sword-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("Daily identity (one 'today' everywhere)", () => {
+    it("shows the local-date daily puzzle numbers from the same hooks the game pages use", () => {
+      mockClassic(328);
+      mockOrder(239);
+
+      render(<GamesGallery />);
+
+      expect(screen.getByText("Puzzle #328")).toBeInTheDocument();
+      expect(screen.getByText("Puzzle #239")).toBeInTheDocument();
+      expect(vi.mocked(useTodaysPuzzle)).toHaveBeenCalled();
+      expect(vi.mocked(useTodaysOrderPuzzle)).toHaveBeenCalled();
+    });
+
+    it("shows a loading skeleton while a daily puzzle resolves", () => {
+      mockClassic(null);
+      mockOrder(239);
+
+      render(<GamesGallery />);
+
+      expect(screen.queryByText("Puzzle #328")).not.toBeInTheDocument();
+      expect(screen.getByText("Puzzle #239")).toBeInTheDocument();
     });
   });
 
@@ -112,14 +173,6 @@ describe("GamesGallery", () => {
       fireEvent.click(screen.getByRole("button", { name: /duel/i }));
 
       expect(mockPush).toHaveBeenCalledWith("/duel");
-    });
-  });
-
-  describe("Data fetching", () => {
-    it("only requests puzzle numbers for deployed daily modes", () => {
-      render(<GamesGallery />);
-
-      expect(vi.mocked(useQuery)).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/components/order/OrderReveal.tsx
+++ b/src/components/order/OrderReveal.tsx
@@ -64,7 +64,7 @@ export function OrderReveal({
   const [isShared, setIsShared] = useState(false);
 
   // Only show countdown for daily puzzles (not archive)
-  const { timeString } = useCountdown({ strategy: "localMidnight" });
+  const { timeString } = useCountdown();
 
   const archivalDisplay = useMemo(() => getArchivalDisplay(score.attempts), [score.attempts]);
 

--- a/src/hooks/__tests__/useCountdown.test.tsx
+++ b/src/hooks/__tests__/useCountdown.test.tsx
@@ -1,14 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 
-vi.mock("convex/react", () => ({
-  useQuery: vi.fn(() => null),
-}));
-
-vi.mock("convex/_generated/api", () => ({
-  api: { puzzles: { getCronSchedule: "puzzles:getCronSchedule" } },
-}));
-
 vi.mock("@/lib/logger", () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
@@ -22,10 +14,7 @@ vi.mock("@/lib/time/dailyDate", () => ({
   getMillisUntilLocalMidnight: () => 3600000,
 }));
 
-import { useQuery } from "convex/react";
 import { useCountdown } from "../useCountdown";
-
-const mockedUseQuery = vi.mocked(useQuery);
 
 describe("useCountdown", () => {
   const originalSetInterval = globalThis.setInterval;
@@ -35,7 +24,6 @@ describe("useCountdown", () => {
     vi.clearAllMocks();
     globalThis.setInterval = (() => 1) as unknown as typeof setInterval;
     globalThis.clearInterval = (() => {}) as unknown as typeof clearInterval;
-    mockedUseQuery.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -43,17 +31,37 @@ describe("useCountdown", () => {
     globalThis.clearInterval = originalClearInterval;
   });
 
-  it("shows loading state with serverMidnight strategy", () => {
-    // With serverMidnight strategy and no query result yet, should show loading
-    const { result, unmount } = renderHook(() => useCountdown({ strategy: "serverMidnight" }));
-    expect(result.current.isLoading).toBe(true);
+  it("never shows a loading state (local midnight is computed client-side)", () => {
+    const { result, unmount } = renderHook(() => useCountdown());
+    expect(result.current.isLoading).toBe(false);
     unmount();
   });
 
-  it("never shows loading state with localMidnight strategy (default)", () => {
-    // Local midnight is computed client-side, no server query needed
+  it("counts down to the player's LOCAL midnight by default", () => {
+    // getMillisUntilLocalMidnight (src/lib/time/dailyDate.ts) is the single
+    // day-resolution source; the mocked 1h remaining renders via
+    // formatCountdown.
     const { result, unmount } = renderHook(() => useCountdown());
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.timeString).toBe("01:00:00");
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it("honors an explicit targetTimestamp override", () => {
+    const { result, unmount } = renderHook(() =>
+      useCountdown({ targetTimestamp: Date.now() + 60_000 }),
+    );
+    expect(result.current.timeString).toBe("01:00:00"); // formatCountdown mocked
+    expect(result.current.isComplete).toBe(false);
+    unmount();
+  });
+
+  it("reports completion when the target has passed", () => {
+    const { result, unmount } = renderHook(() =>
+      useCountdown({ targetTimestamp: Date.now() - 1000 }),
+    );
+    expect(result.current.isComplete).toBe(true);
+    expect(result.current.timeString).toBe("00:00:00");
     unmount();
   });
 });

--- a/src/hooks/__tests__/useStreak.test.tsx
+++ b/src/hooks/__tests__/useStreak.test.tsx
@@ -73,11 +73,11 @@ describe("useStreak", () => {
 
       const { result } = renderHook(() => useStreak());
 
-      // Mock today's date to ensure deterministic testing
+      // Mock today's LOCAL date (canonical day semantics) for determinism
       const mockToday = "2025-01-16";
-      vi.spyOn(Date.prototype, "getUTCFullYear").mockReturnValue(2025);
-      vi.spyOn(Date.prototype, "getUTCMonth").mockReturnValue(0); // January (0-indexed)
-      vi.spyOn(Date.prototype, "getUTCDate").mockReturnValue(16);
+      vi.spyOn(Date.prototype, "getFullYear").mockReturnValue(2025);
+      vi.spyOn(Date.prototype, "getMonth").mockReturnValue(0); // January (0-indexed)
+      vi.spyOn(Date.prototype, "getDate").mockReturnValue(16);
 
       // Update streak after winning
       act(() => {
@@ -119,10 +119,10 @@ describe("useStreak", () => {
 
       const { result } = renderHook(() => useStreak());
 
-      // Mock today's date
-      vi.spyOn(Date.prototype, "getUTCFullYear").mockReturnValue(2025);
-      vi.spyOn(Date.prototype, "getUTCMonth").mockReturnValue(0);
-      vi.spyOn(Date.prototype, "getUTCDate").mockReturnValue(16);
+      // Mock today's LOCAL date (canonical day semantics)
+      vi.spyOn(Date.prototype, "getFullYear").mockReturnValue(2025);
+      vi.spyOn(Date.prototype, "getMonth").mockReturnValue(0);
+      vi.spyOn(Date.prototype, "getDate").mockReturnValue(16);
 
       // Update streak after losing
       act(() => {

--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -1,16 +1,13 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useQuery } from "convex/react";
 import {
   calculateCountdownTime,
   shouldTriggerCompletion,
   didCountdownRestart,
 } from "@/lib/time/countdownCalculation";
 import { getMillisUntilLocalMidnight } from "@/lib/time/dailyDate";
-import { anyPublicApi } from "@/lib/convexAnyApi";
 import { logger } from "@/lib/logger";
-import { useClientSnapshot } from "@/hooks/useClientSnapshot";
 
 export interface UseCountdownReturn {
   timeString: string;
@@ -19,116 +16,49 @@ export interface UseCountdownReturn {
   error: string | null;
 }
 
-/**
- * Countdown strategy determines the target time source
- *
- * - "localMidnight": Uses client's local midnight (primary for daily puzzles)
- * - "serverMidnight": Uses Convex getCronSchedule (legacy behavior)
- */
-export type CountdownStrategy = "localMidnight" | "serverMidnight";
-
 export interface UseCountdownOptions {
   /**
-   * Countdown strategy - determines target time source
-   * Default: "localMidnight" (new behavior for daily unlock)
-   */
-  strategy?: CountdownStrategy;
-
-  /**
    * Target timestamp (Unix milliseconds) to countdown to.
-   * If provided, overrides both strategy and query.
-   * Still supported for archive/testing scenarios.
+   * If provided, overrides the local-midnight default.
+   * Supported for archive/testing scenarios.
    */
   targetTimestamp?: number;
-
-  /**
-   * Whether to use fallback local midnight calculation
-   * when server strategy fails. Defaults to true.
-   * Only relevant for "serverMidnight" strategy.
-   */
-  enableFallback?: boolean;
 }
 
+/**
+ * Countdown to the next daily puzzle.
+ *
+ * Day semantics: the next puzzle unlocks at the PLAYER'S local midnight —
+ * Chrondle's canonical "today" is the player's local calendar day (see
+ * src/lib/time/dailyDate.ts), and this hook derives its target from that
+ * module's getMillisUntilLocalMidnight. There is deliberately no server-clock
+ * strategy: a server-derived rollover would disagree with the puzzle the
+ * player is shown.
+ */
 export function useCountdown(options: UseCountdownOptions = {}): UseCountdownReturn {
-  const { strategy = "localMidnight", targetTimestamp, enableFallback = true } = options;
+  const { targetTimestamp } = options;
 
   const [timeString, setTimeString] = useState("00:00:00");
   const [isComplete, setIsComplete] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Only fetch cron schedule if using serverMidnight strategy and no explicit target
-  const shouldQueryServer = strategy === "serverMidnight" && !targetTimestamp;
-  const cronSchedule = useQuery(
-    anyPublicApi.puzzles.getCronSchedule,
-    shouldQueryServer ? {} : "skip",
-  ) as { nextScheduledTime: number } | null | undefined;
-  const localMidnightTarget = useClientSnapshot(
-    () => Date.now() + getMillisUntilLocalMidnight(),
-    () => 0,
-  );
-
-  // Calculate effective target timestamp based on strategy
-  let effectiveTarget: number | undefined;
-  let isLoading = false;
-
-  if (targetTimestamp) {
-    // Explicit target takes precedence
-    effectiveTarget = targetTimestamp;
-  } else if (strategy === "localMidnight") {
-    // Local midnight strategy: compute from client time (never loading)
-    effectiveTarget = localMidnightTarget;
-  } else {
-    // Server midnight strategy: use cron schedule
-    effectiveTarget = cronSchedule?.nextScheduledTime;
-    isLoading = cronSchedule === undefined;
-  }
-
-  // Reset completion state when target changes
   useEffect(() => {
-    if (effectiveTarget && isComplete) {
-      const timeout = setTimeout(() => {
-        setIsComplete(false);
-        logger.warn("[useCountdown] New target detected, resetting completion state");
-      }, 0);
-
-      return () => clearTimeout(timeout);
-    }
-  }, [effectiveTarget, isComplete]);
-
-  useEffect(() => {
-    if (isLoading) {
-      const timeout = setTimeout(() => {
-        setTimeString("00:00:00");
-      }, 0);
-
-      return () => clearTimeout(timeout);
-    }
-
     const updateCountdown = () => {
       try {
-        // For local midnight strategy, recalculate target each tick
+        // For the local-midnight default, recalculate the target each tick
         // (ensures we stay accurate across midnight boundaries)
-        const currentTarget =
-          strategy === "localMidnight" && !targetTimestamp
-            ? Date.now() + getMillisUntilLocalMidnight()
-            : effectiveTarget;
+        const currentTarget = targetTimestamp ?? Date.now() + getMillisUntilLocalMidnight();
 
         const result = calculateCountdownTime(
           {
             targetTimestamp: currentTarget,
-            enableFallback: strategy === "serverMidnight" ? enableFallback : false,
+            enableFallback: false,
           },
           Date.now(),
         );
 
         setTimeString(result.timeString);
-
-        // Only surface errors for server strategy (local can't fail)
-        if (strategy === "serverMidnight") {
-          setError(result.error);
-        } else {
-          setError(null);
-        }
+        setError(null);
 
         // Handle completion transition
         if (shouldTriggerCompletion(result, isComplete)) {
@@ -151,12 +81,13 @@ export function useCountdown(options: UseCountdownOptions = {}): UseCountdownRet
     const interval = setInterval(updateCountdown, 1000);
 
     return () => clearInterval(interval);
-  }, [effectiveTarget, isLoading, enableFallback, isComplete, strategy, targetTimestamp]);
+  }, [isComplete, targetTimestamp]);
 
   return {
     timeString,
     isComplete,
-    isLoading,
+    // Local midnight is computed client-side; there is nothing to load.
+    isLoading: false,
     error,
   };
 }

--- a/src/hooks/useQueryWithRetry.ts
+++ b/src/hooks/useQueryWithRetry.ts
@@ -18,8 +18,8 @@ export type { RetryConfig };
  * @example
  * ```typescript
  * const result = useQueryWithRetry(
- *   api.puzzles.getDailyPuzzle,
- *   undefined,
+ *   api.puzzles.getPuzzleByDate,
+ *   { date: localDate },
  *   {
  *     maxRetries: 3,
  *     onRetry: (attempt, error) => {
@@ -49,7 +49,7 @@ export function useQueryWithRetry<
  * @example
  * ```typescript
  * export const usePuzzleDataWithRetry = createQueryHookWithRetry(
- *   api.puzzles.getDailyPuzzle,
+ *   api.puzzles.getPuzzleByDate,
  *   { maxRetries: 5 }
  * );
  * ```

--- a/src/hooks/useStreak.ts
+++ b/src/hooks/useStreak.ts
@@ -5,11 +5,8 @@ import { useUser } from "@clerk/nextjs";
 import { useQuery, useMutation } from "convex/react";
 import { anonymousStreakStorage } from "@/lib/secureStorage";
 import { anyPublicApi } from "@/lib/convexAnyApi";
-import {
-  calculateStreakUpdate,
-  applyStreakUpdate,
-  getUTCDateString,
-} from "../../convex/lib/streakCalculation";
+import { calculateStreakUpdate, applyStreakUpdate } from "../../convex/lib/streakCalculation";
+import { getLocalDateString } from "@/lib/time/dailyDate";
 import { STREAK_CONFIG } from "@/lib/constants";
 import { logger } from "@/lib/logger";
 
@@ -102,8 +99,12 @@ export function useStreak(): UseStreakReturn {
     (hasWon: boolean): StreakData => {
       if (isSignedIn && convexUser) {
         // Authenticated: Calculate optimistic update while backend processes
-        // submitGuess mutation handles actual persistence, but we provide immediate feedback
-        const today = getUTCDateString();
+        // submitGuess mutation handles actual persistence, but we provide immediate feedback.
+        // Canonical day semantics: the player's LOCAL calendar day — this
+        // matches the date of the daily puzzle being completed (game pages
+        // resolve puzzles by local date) and the server's puzzle-date-based
+        // streak update.
+        const today = getLocalDateString();
 
         const update = calculateStreakUpdate(
           convexUser.lastCompletedDate || null,
@@ -140,7 +141,8 @@ export function useStreak(): UseStreakReturn {
         let resultData: StreakData | null = null;
 
         setAnonymousStreak((prev) => {
-          const today = getUTCDateString();
+          // Local calendar day: same day marker the daily puzzle carries.
+          const today = getLocalDateString();
 
           // Calculate what should happen (explicit command pattern)
           const update = calculateStreakUpdate(

--- a/src/lib/time/dailyDate.ts
+++ b/src/lib/time/dailyDate.ts
@@ -1,12 +1,19 @@
 /**
- * Daily Date Module
+ * Daily Date Module — THE canonical day-resolution module
+ *
+ * Chrondle's canonical "today" is the PLAYER'S LOCAL CALENDAR DAY. Every
+ * user-facing daily surface derives its day from this module: the homepage
+ * gallery and game pages (via useTodaysPuzzle / useTodaysOrderPuzzle), the
+ * archive today-boundary, the next-puzzle countdown (local midnight), and the
+ * optimistic streak day marker. Server-side streak boundaries derive from the
+ * puzzle's date, which is itself resolved from this module by the client.
+ *
+ * Do NOT resolve a UI "today" any other way — in particular, never from a
+ * server clock. The UTC-day Convex queries (getDailyPuzzle /
+ * getDailyOrderPuzzle) are quarantined and lint-banned in src/. See the
+ * "Daily Day Semantics" section of README.md for the full rationale.
  *
  * Deep Module: Hides timezone complexity behind simple date string interface.
- *
- * Used by:
- * - usePuzzleData (daily branch)
- * - useOrderPuzzleData (daily branch)
- * - Any future daily features (notifications, local streak policy)
  *
  * Key Decisions:
  * - Derives from Date local fields (getFullYear/getMonth/getDate)


### PR DESCRIPTION
## Summary

Fixes the live trust bug where the homepage advertised **tomorrow's** puzzle every evening (Powder card `chrondle-ux-daily-identity`, absorbs `backlog.d/007`).

**Root cause:** two clocks. Game pages resolve the daily puzzle by the **client's local date**, but the homepage gallery queried the UTC-day `getDailyPuzzle`/`getDailyOrderPuzzle` (server clock). After 00:00 UTC (~5pm PT) they diverge by one day — live evidence on the card: gallery said `#329/#240`, tapping through played `#328/#239`. Streaks shared the root cause: `updateUserStreak` classified "daily" by server-UTC equality, so an evening completion of today's local puzzle was silently treated as archive (**no streak update**), and a UTC+14 player replaying an older day could **reset** a live streak.

**Canonical semantics (now documented):** "today" is the **player's local calendar day**; the single day-resolution module is `src/lib/time/dailyDate.ts`. See README "Daily Day Semantics" + AGENTS.md.

## Changes

- **Gallery:** `GamesGallery` consumes `useTodaysPuzzle`/`useTodaysOrderPuzzle` — the exact hooks the game pages use — so homepage numbers cannot diverge from the game header.
- **Order SSR preload:** seeds via `getOrderPuzzleByDate` with an explicit date; the client hook validates it against local date and refetches on mismatch (proven live in the e2e log: `Preload date mismatch: preload=2026-07-07, local=2026-07-06`).
- **Quarantine:** `getDailyPuzzle`/`getDailyOrderPuzzle` kept only for stale client bundles (deleting them would hard-error sessions opened before deploy), documented as deprecated, and **lint-banned in `src/`** via `no-restricted-syntax` (probe-verified).
- **Streaks:** boundary derives from the **puzzle's date** (consecutive puzzle dates = consecutive days); a puzzle is "daily" within a ±1-day timezone envelope (UTC-12..UTC+14) of server-UTC; new never-rewind guard stops older-dated plays from resetting a newer streak. Decision extracted as pure `shouldUpdateStreakForPuzzle` and tested directly.
- **Countdown:** dead `serverMidnight` strategy deleted; local midnight (from `dailyDate.ts`) is the only rollover clock. `useStreak` optimistic updates now use local dates.
- **Docs:** README's stale "midnight Central Time" scheduling section replaced with the canonical day-semantics section; AGENTS.md gets a do-not-re-litigate note; `backlog.d/007` marked absorbed.

## Verification

- `bunx eslint src convex e2e eslint.config.mjs --max-warnings=0` — clean
- `bun run type-check` — clean
- `bun run test` — **151 files / 1985 tests passed** (incl. new `convex/__tests__/streakDayBoundary.convex.test.ts` driving the real `submitGuess` mutation across UTC boundaries with fake timers)
- **Clock-frozen e2e** `e2e/daily-identity.spec.ts` (`bunx playwright test e2e/daily-identity.spec.ts --project=chromium`): freezes the browser to yesterday-evening LA time (browser-local date ≠ browser-UTC date ≠ server real date) and asserts homepage mode-card numbers == game-page header numbers for Classic and Order — **2 passed**; **proven red against the old gallery code** (stashed the fix → Classic test failed → restored).
- `bunx playwright test e2e/game-flow.spec.ts --project=chromium` — 11 passed (gallery-to-classic flow).

## Notes for review

- Semantics change: a puzzle dated one day off server-UTC now counts as daily for streaks — this is the price of honoring real timezones without trusting extra client claims; anything ≥2 days out remains archive, and the never-rewind guard bounds replay abuse.
- The quarantined queries should be deleted after a release window (stale-bundle compat only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)