### PR TITLE
fix(nav): value-bearing gallery escape hatch survives Vercel edge (chrondle-ux-mode-hub-escape-hatch)

### DIFF
--- a/e2e/habit-loop.spec.ts
+++ b/e2e/habit-loop.spec.ts
@@ -127,7 +127,10 @@ test.describe("Entry @habit-loop", () => {
   }) => {
     await context.addCookies([{ name: "chrondle_mode", value: "classic", url: BASE_URL }]);
 
-    await page.goto("/?all");
+    // Navigate the exact value-bearing form the header wordmark emits (`/?all=1`).
+    // Bare `/?all` is dropped by Vercel edge normalization in production; the
+    // value-bearing param is what actually keeps the gallery reachable there.
+    await page.goto("/?all=1");
     await expect(page.getByRole("heading", { level: 1, name: "Chrondle" })).toBeVisible();
     await expect(page.getByRole("button", { name: /order/i })).toBeVisible();
   });

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -11,8 +11,12 @@ interface HomepageProps {
 /**
  * Home is a first-touch surface: returning visitors (mode-preference cookie)
  * are sent straight to their preferred mode — zero extra taps — while
- * first-timers get the gallery pitch. `/?all` always shows the gallery
- * (that's where the in-app wordmark points), so the mode hub stays reachable.
+ * first-timers get the gallery pitch. A value-bearing `all` param (`/?all=1`)
+ * forces the gallery, keeping the mode hub reachable — that's where the in-app
+ * wordmark points. NOTE: the param must carry a value. Vercel edge query
+ * normalization drops valueless params, so a bare `/?all` arrives here as
+ * `undefined`, the redirect fires, and the wordmark becomes a production
+ * dead-end (this shipped once — see chrondle-ux-mode-hub-escape-hatch).
  */
 export default async function Homepage({ searchParams }: HomepageProps) {
   const [params, cookieStore] = await Promise.all([searchParams, cookies()]);

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -44,9 +44,13 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           <div className="flex min-h-[40px] items-center justify-between">
             {/* Logo/Brand - with integrated mode switcher */}
             <div className="flex h-10 items-baseline gap-2">
-              {/* `/?all` keeps the gallery reachable for players whose
-                  mode-preference cookie redirects bare `/` to their mode. */}
-              <Link href="/?all" className="flex items-baseline">
+              {/* Keeps the gallery reachable for players whose mode-preference
+                  cookie redirects bare `/` to their mode. The param MUST carry
+                  a value (`all=1`, not bare `?all`): Vercel edge query
+                  normalization drops valueless params, so bare `?all` reaches
+                  the server as `undefined` and the home redirect fires anyway,
+                  turning the wordmark into a dead-end in production. */}
+              <Link href="/?all=1" className="flex items-baseline">
                 <h1 className="font-display text-body-primary m-0 flex cursor-pointer items-baseline text-2xl transition-opacity hover:opacity-80 md:text-3xl">
                   <span className="flex h-10 w-10 items-center justify-center sm:hidden">C</span>
                   <span className="hidden sm:inline">CHRONDLE</span>

--- a/src/components/__tests__/AppHeader.test.tsx
+++ b/src/components/__tests__/AppHeader.test.tsx
@@ -59,4 +59,17 @@ describe("AppHeader", () => {
     render(<AppHeader puzzleNumber={42} />);
     expect(screen.getByText(/42/)).toBeTruthy();
   });
+
+  // Regression guard for the live-prod mode-hub dead-end: the wordmark's
+  // gallery escape hatch must use a value-bearing `all` param. Bare `/?all` is
+  // stripped by Vercel edge query normalization, so the home redirect reads
+  // `all` as undefined and bounces a returning visitor straight back to their
+  // mode — the mode hub becomes unreachable from `/`. A value survives.
+  it("wordmark escapes to the gallery with a value-bearing param (survives edge normalization)", () => {
+    render(<AppHeader />);
+    const wordmark = screen.getByRole("heading", { level: 1 }).closest("a");
+    expect(wordmark).not.toBeNull();
+    const href = wordmark?.getAttribute("href") ?? "";
+    expect(href).toMatch(/^\/\?all=.+/); // e.g. /?all=1 — never bare /?all
+  });
 });


### PR DESCRIPTION
## Live-prod regression fix

Fresh-context verification of PR #270 (habit loop) caught this: the header wordmark links to bare `/?all` as the gallery/mode-switcher escape hatch for returning visitors, and `e2e/habit-loop.spec.ts` asserts that path works. It passes locally but **fails on Vercel** — the edge drops the valueless query param, so `src/app/(app)/page.tsx` reads `params.all` as `undefined`, the mode redirect fires, and a returning visitor (with a `chrondle_mode` cookie) tapping the wordmark is bounced right back to their mode. The mode hub is unreachable from `/` in production.

### Reproduced live 2026-07-07 (cookie=order)
| URL | Result |
|---|---|
| `/?all` (bare) | **307 → /order** (broken) |
| `/?all=1` | 200 gallery |
| `/?all=true` | 200 gallery |
| `/` no cookie | 200 gallery |

Root cause: presence-of-valueless-param semantics (`params.all !== undefined`) is fragile against Vercel edge query normalization; the local Next dev server parses bare `?all` as `""` (defined), so CI never saw it.

### Fix
- `AppHeader.tsx` wordmark → `/?all=1` (value-bearing; survives edge normalization)
- `AppHeader.test.tsx` — new unit guard asserting the wordmark link is value-bearing; **red-green proven** (fails on bare `/?all`, passes on `/?all=1`)
- `e2e/habit-loop.spec.ts` navigates the exact form the header emits
- Documented the edge-normalization footgun at the redirect site

Local gates green: type-check, eslint (changed files), AppHeader vitest 4/4. Full suite + e2e gated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)