### PR TITLE
docs(agents): close the Dagger CI documentation gap

### DIFF
--- a/.claude/skills/chrondle-verify/SKILL.md
+++ b/.claude/skills/chrondle-verify/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: chrondle-verify
+description: >
+  Run before claiming any chrondle change is done. Runs the fast local gate
+  and the Dagger-wrapped CI-equivalent gate — the same two things
+  .github/workflows/ci.yml enforces on every PR — so "green locally" and
+  "green in CI" mean the same thing. Use when finishing a change, before
+  opening a PR, or when asked to "verify", "run the gate", "run CI locally",
+  or "check this is ready to ship".
+---
+
+# chrondle-verify
+
+Chrondle is gated by two loops, not one. `AGENTS.md`'s pre-commit line
+(`bun run lint && bun run type-check && bun run test`) is the fast local
+loop. `.github/workflows/ci.yml` actually gates PRs with the **Dagger**
+wrapped equivalent (`dagger call quality --check=lint|type-check` and
+`dagger call test-coverage-artifacts`) — a different execution path that can
+catch things the raw `bun run` commands don't (e.g. coverage thresholds).
+Run both before calling a change done; the fast loop first (cheap, tight
+iteration), the Dagger loop before opening or merging a PR.
+
+## Fast local gate (iterate on this)
+
+```bash
+bun run lint && bun run type-check && bun run test
+```
+
+Matches `package.json`'s `lint` / `type-check` / `test` scripts exactly.
+This is the loop to run in a tight edit-test cycle.
+
+## CI-equivalent gate (Dagger — matches what actually gates the PR)
+
+Requires the `dagger` CLI and a working Docker/Colima backend
+(`scripts/dagger-local.sh` auto-detects Colima via `CHRONDLE_COLIMA_PROFILE`,
+default `default`).
+
+```bash
+bun run ci:dagger:lint          # dagger call quality --check=lint
+bun run ci:dagger:type-check    # dagger call quality --check=type-check
+bun run ci:dagger:coverage      # dagger call test-coverage-artifacts --output=coverage
+```
+
+These three map 1:1 to the `quality-checks` matrix (`lint`, `type-check`,
+`test`) in `.github/workflows/ci.yml`. Run all three before opening a PR if
+Dagger/Docker is available locally; if it isn't, say so explicitly rather than
+treating the fast local gate as CI-equivalent proof — they are not the same
+gate.
+
+Other `ci:dagger:*` scripts exist for the non-matrix CI jobs:
+`ci:dagger:validation`, `ci:dagger:docs`.
+
+## Known gaps (do not paper over)
+
+- If `bun run lint`/`type-check`/`test` fails on files you did not touch
+  (e.g. stray scratch files from another agent session at repo root), that is
+  pre-existing pollution, not your regression — name it explicitly in your
+  proof rather than silently treating the run as green or quietly fixing
+  unrelated files.
+- A fast-local pass is not proof the PR will go green — only the Dagger gate
+  or the actual CI run is.
+
+## Deployed-surface checks (separate from the code gate)
+
+Not part of the merge gate, but the discoverable commands for verifying the
+live app — see "Deployed Surfaces" in `AGENTS.md` for when to run each of
+`bun run deploy:verify`, `bun run deployment:check`, and
+`bun run validate-puzzles`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,10 +143,22 @@ Never reveal the answer outside the hint system. No "smart" era selection. No "t
 - `bun build` then `bun start` — For production preview.
 - `bun test`, `bun lint`, `bun type-check` — To verify the integrity of the scroll.
 - `bun quality` — The high-level audit of our dependencies and cache.
+- **Run the `.claude/skills/chrondle-verify` skill** before claiming a change
+  is done — it runs both gates below in the right order.
+
+There are two gates, not one, and they are not interchangeable:
 
 ```bash
-# Before committing
+# 1. Fast local gate — tight edit/test loop, matches the raw bun scripts
 bun run lint && bun run type-check && bun run test
+
+# 2. CI-equivalent gate — the ACTUAL gate .github/workflows/ci.yml enforces
+#    on every PR, wrapped in Dagger (requires the dagger CLI + Docker/Colima).
+#    Run this before opening/merging a PR; the raw `bun run` commands above
+#    can pass while this fails (e.g. coverage thresholds).
+bun run ci:dagger:lint          # dagger call quality --check=lint
+bun run ci:dagger:type-check    # dagger call quality --check=type-check
+bun run ci:dagger:coverage      # dagger call test-coverage-artifacts --output=coverage
 
 # Convex DB integrity
 bunx convex run puzzles:getTotalPuzzles
@@ -155,6 +167,23 @@ bunx convex run puzzles:getTotalPuzzles
 bunx convex dev  # Terminal 1
 bun run dev      # Terminal 2
 ```
+
+## Deployed Surfaces
+
+Verifying the live app (Vercel + Convex prod) is a separate concern from the
+code gate above. Three discoverable scripts cover it:
+
+- `bun run deployment:check` (`scripts/check-deployment-ready.mjs`) — **before
+  deploying.** Pre-deploy readiness: generated Convex files present, clean git
+  status, `vercel.json` sane, env vars set, TypeScript clean, build scripts
+  present.
+- `bun run deploy:verify` (`scripts/verify-deployment.mjs`) — **after
+  deploying.** Post-deploy health check: Convex connectivity, event-table
+  stats, cron/daily-generation activity, and today's puzzle (existence +
+  integrity — no leaked answers).
+- `bun run validate-puzzles` (`scripts/check-convex-state.mjs`) — **ad hoc.**
+  Read-only snapshot of live Convex state (today's puzzle + archive) for
+  debugging, independent of deploy timing.
 
 ## Coding Style & Naming Conventions
 


### PR DESCRIPTION
## Summary
- AGENTS.md's Rituals section only documented `bun run lint/type-check/test`, not the Dagger-wrapped equivalent `.github/workflows/ci.yml` actually enforces on every PR (`ci:dagger:lint`, `ci:dagger:type-check`, `ci:dagger:coverage`) — an agent following AGENTS.md literally could pass locally and still diverge from CI (e.g. coverage thresholds only enforced in the Dagger path).
- Added `.claude/skills/chrondle-verify/SKILL.md`: a repo-local skill an agent can run cold, covering both the fast local gate and the Dagger CI-equivalent gate.
- Added a "Deployed Surfaces" section to AGENTS.md documenting when to run `deployment:check` (pre-deploy), `deploy:verify` (post-deploy health), and `validate-puzzles` (ad hoc Convex state snapshot) — previously scripts existed with no narrative pointer.

Closes Powder card `chrondle-eng-agent-readiness`.

## Test plan
- [x] `bun run type-check` — clean
- [x] `bun run test` — 2012 passed, 3 skipped (full suite green)
- [x] Confirmed `dagger`, `colima`, `docker` CLIs are present locally so `ci:dagger:*` scripts referenced in the new docs are actually runnable
- [x] `bun run lint` — fails only on 8 untracked `check-lab001*.mjs` scratch files at repo root belonging to a concurrent agent session (unrelated to this diff; left untouched per repo convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)