### PR TITLE
chore(eng): restore lint gate against ad-hoc check-lab*.mjs litter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,9 @@ test-results/
 .design-catalogue/
 
 .flywheel/
+
+# Ad-hoc probe scripts left at repo root by agent sessions (not chrondle
+# product code; commonly Playwright scripts poking an unrelated local
+# harness). Ignored rather than deleted since ownership is ambiguous and
+# they may belong to a concurrent session. See chrondle-eng-repo-litter.
+/check-lab*.mjs

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,18 @@ const [mainConfig, tsConfig, ignoresConfig] = nextConfig;
 
 const eslintConfig = [
   {
-    ignores: ["**/*.css", "convex/_generated/**", "coverage/**", "dagger/sdk/**"],
+    // check-lab*.mjs: ad-hoc probe scripts left at repo root by an
+    // unrelated agent session (not chrondle product code). Gitignored
+    // rather than deleted since ownership is ambiguous; also excluded
+    // here so their console/debug usage doesn't fail the lint gate.
+    // See chrondle-eng-repo-litter.
+    ignores: [
+      "**/*.css",
+      "convex/_generated/**",
+      "coverage/**",
+      "dagger/sdk/**",
+      "check-lab*.mjs",
+    ],
   },
   // Main Next.js config
   mainConfig,


### PR DESCRIPTION
## Summary
- 8 untracked `check-lab*.mjs` Playwright probe scripts at repo root (leftover from an unrelated agent session poking a localhost:8123 design-lab harness) were breaking `bun run lint` with 32 `no-console` errors
- Ownership of these files is ambiguous (may belong to a concurrent agent session), so they are **not deleted** — instead gitignored and eslint-ignored so the lint gate is clean without touching them

## Test plan
- [x] `git status --short --untracked-files=all` no longer lists `check-lab*.mjs` at repo root
- [x] `bun run lint` passes clean with no `--ignore-pattern` flag needed
- [x] `bun run type-check` clean
- [x] `check-lab001*.mjs` files still present on disk (confirmed via `ls`)

Closes chrondle-eng-repo-litter (Powder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)