### PR TITLE
feat: add one-gesture classic range entry

### DIFF
--- a/docs/labs/classic-range-entry-lab.html
+++ b/docs/labs/classic-range-entry-lab.html
@@ -1,0 +1,1121 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chrondle Classic Range-Entry Lab</title>
+    <style>
+      :root {
+        --bg: #faf7f2;
+        --card: #ffffff;
+        --ink: #1c1917;
+        --muted: #78716c;
+        --line: #e7e0d8;
+        --accent: #0e7490;
+        --accent-mark: #0e7490;
+        --good: #15803d;
+        --bad: #b91c1c;
+        --win: #166534;
+        --warn: #b45309;
+        --cta-bg: #166534;
+        --cta-fg: #ffffff;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #171412;
+          --card: #211d1a;
+          --ink: #f5f0ea;
+          --muted: #a89f95;
+          --line: #3a332c;
+          --accent: #22d3ee;
+          --accent-mark: #155e75;
+          --good: #4ade80;
+          --bad: #f87171;
+          --win: #86efac;
+          --warn: #f59e0b;
+          --cta-bg: #15803d;
+          --cta-fg: #ffffff;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: "Avenir Next", Avenir, "Trebuchet MS", sans-serif;
+        font-size: 15px;
+        line-height: 1.55;
+        background: var(--bg);
+        color: var(--ink);
+        padding: 0 0 6rem;
+      }
+      header.lab {
+        padding: 2.5rem 1.25rem 1rem;
+        max-width: 74rem;
+        margin: 0 auto;
+      }
+      h1 {
+        font-size: 1.7rem;
+        margin: 0 0 0.4rem;
+      }
+      .sub {
+        color: var(--muted);
+        max-width: 56rem;
+      }
+      .rule {
+        max-width: 56rem;
+        margin-top: 1rem;
+        padding: 0.75rem 1rem;
+        border: 1px solid var(--line);
+        border-color: color-mix(in srgb, var(--accent) 35%, var(--line));
+        border-radius: 6px;
+        font-size: 0.85rem;
+        background: var(--card);
+      }
+      nav.toc {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+        max-width: 74rem;
+        margin: 1rem auto;
+        padding: 0 1.25rem;
+        position: sticky;
+        top: 0;
+        background: var(--bg);
+        padding-top: 0.6rem;
+        padding-bottom: 0.6rem;
+        border-bottom: 1px solid var(--line);
+        z-index: 5;
+      }
+      nav.toc a {
+        font-size: 0.8rem;
+        padding: 0.25rem 0.55rem;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        text-decoration: none;
+        color: var(--ink);
+        background: var(--card);
+      }
+      nav.toc a.win {
+        border-color: var(--win);
+        color: var(--win);
+        font-weight: 700;
+      }
+      section.opt {
+        max-width: 74rem;
+        margin: 2rem auto;
+        padding: 0 1.25rem;
+      }
+      .optcard {
+        background: var(--card);
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        overflow: visible;
+      }
+      .opthead {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 1rem;
+        padding: 1rem 1.25rem;
+        border-bottom: 1px solid var(--line);
+        flex-wrap: wrap;
+      }
+      .opthead h2 {
+        font-size: 1.05rem;
+        margin: 0;
+      }
+      .tag {
+        font-size: 0.8rem;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+      .winner-badge {
+        font-size: 0.8rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--win);
+        border: 1.5px solid var(--win);
+        border-radius: 999px;
+        padding: 0.15rem 0.6rem;
+        font-weight: 700;
+      }
+      .body {
+        display: grid;
+        grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+        gap: 0;
+      }
+      @media (max-width: 820px) {
+        .body {
+          grid-template-columns: 1fr;
+        }
+      }
+      .mock {
+        padding: 1.25rem;
+        border-right: 1px solid var(--line);
+        background: repeating-linear-gradient(
+          45deg,
+          transparent,
+          transparent 12px,
+          rgba(120, 113, 108, 0.04) 12px,
+          rgba(120, 113, 108, 0.04) 13px
+        );
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      @media (max-width: 820px) {
+        .mock {
+          border-right: none;
+          border-bottom: 1px solid var(--line);
+        }
+      }
+      .notes {
+        padding: 1.1rem 1.25rem;
+        font-size: 0.88rem;
+      }
+      .notes h3 {
+        font-size: 0.8rem;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+        margin: 0.9rem 0 0.25rem;
+      }
+      .notes h3:first-child {
+        margin-top: 0;
+      }
+      .notes ul {
+        margin: 0.2rem 0 0.4rem 1.1rem;
+        padding: 0;
+      }
+      .notes li {
+        margin: 0.15rem 0;
+      }
+      /* phone frame */
+      .ph {
+        width: 300px;
+        max-width: 100%;
+        background: var(--bg);
+        border: 2px solid var(--line);
+        border-radius: 18px;
+        padding: 0.9rem 0.8rem;
+        font-size: 0.8rem;
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.07);
+      }
+      .ph .brand {
+        font-family: ui-serif, Georgia, serif;
+        font-weight: 800;
+        text-align: center;
+        font-size: 1rem;
+        letter-spacing: 0.02em;
+        margin-bottom: 0.6rem;
+      }
+      .ph .dim {
+        color: var(--muted);
+      }
+      .card {
+        border: 1.5px solid var(--line);
+        border-radius: 8px;
+        padding: 0.7rem;
+        background: var(--card);
+      }
+      .teach {
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.8rem;
+        color: var(--accent);
+        font-weight: 600;
+        margin-bottom: 0.55rem;
+      }
+      /* timeline bar */
+      .bar {
+        position: relative;
+        height: 34px;
+        background: color-mix(in srgb, var(--ink) 6%, transparent);
+        border-radius: 999px;
+        margin: 0.5rem 0;
+      }
+      .bar .fill {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        background: color-mix(in srgb, var(--accent-mark) 35%, transparent);
+        border-radius: 999px;
+      }
+      .bar .tick0 {
+        position: absolute;
+        top: -3px;
+        bottom: -3px;
+        width: 1.5px;
+        background: var(--line);
+      }
+      .bar .handle {
+        position: absolute;
+        top: 50%;
+        width: 18px;
+        height: 18px;
+        border-radius: 999px;
+        background: var(--card);
+        border: 2.5px solid var(--accent);
+        transform: translate(-50%, -50%);
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+      }
+      .axis {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.8rem;
+        color: var(--muted);
+        margin-top: 0.15rem;
+      }
+      .readout {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 0.8rem;
+        margin-top: 0.55rem;
+      }
+      .readout .worth {
+        color: var(--good);
+        font-weight: 700;
+      }
+      .cta {
+        margin-top: 0.6rem;
+        height: 30px;
+        border-radius: 6px;
+        background: var(--cta-bg);
+        color: var(--cta-fg);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.8rem;
+        font-weight: 700;
+        letter-spacing: 0.03em;
+      }
+      .fallback {
+        margin-top: 0.5rem;
+        font-size: 0.8rem;
+        color: var(--muted);
+        border-top: 1px dashed var(--line);
+        padding-top: 0.4rem;
+        display: flex;
+        justify-content: space-between;
+      }
+      /* dial */
+      .dial {
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+        border: 3px solid var(--line);
+        position: relative;
+        margin: 0.5rem auto;
+        padding: 0.75rem;
+        background: conic-gradient(
+          color-mix(in srgb, var(--accent-mark) 30%, transparent) 0deg 70deg,
+          transparent 70deg 360deg
+        );
+      }
+      .dial .nub {
+        position: absolute;
+        top: 6px;
+        left: 50%;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--accent-mark);
+        transform: translateX(-50%);
+      }
+      .dial .center {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+      }
+      .dial .center b {
+        font-size: 0.85rem;
+      }
+      .dial .center span {
+        font-size: 0.8rem;
+        color: var(--muted);
+      }
+      /* wheel */
+      .wheel {
+        height: 80px;
+        overflow: hidden;
+        position: relative;
+        border: 1.5px solid var(--line);
+        border-radius: 8px;
+        background: var(--card);
+      }
+      .wheel .row {
+        text-align: center;
+        padding: 0.15rem 0;
+        color: var(--muted);
+        font-size: 0.8rem;
+      }
+      .wheel .row.sel {
+        color: var(--ink);
+        font-weight: 800;
+        font-size: 0.85rem;
+      }
+      .wheel::before,
+      .wheel::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        height: 26px;
+        pointer-events: none;
+      }
+      .wheel::before {
+        top: 0;
+        background: linear-gradient(var(--card), transparent);
+      }
+      .wheel::after {
+        bottom: 0;
+        background: linear-gradient(transparent, var(--card));
+      }
+      /* chips */
+      .chips {
+        display: flex;
+        gap: 0.3rem;
+        flex-wrap: wrap;
+        margin-top: 0.4rem;
+      }
+      .chip {
+        border: 1.5px solid var(--line);
+        border-radius: 999px;
+        padding: 0.2rem 0.55rem;
+        font-size: 0.8rem;
+        background: var(--card);
+      }
+      .chip.sel {
+        border-color: var(--accent);
+        color: var(--accent);
+        font-weight: 700;
+        background: color-mix(in srgb, var(--accent-mark) 10%, transparent);
+      }
+      /* mural */
+      .mural {
+        height: 34px;
+        border-radius: 8px;
+        background: linear-gradient(
+          90deg,
+          #8a7355,
+          #a68a5b 20%,
+          #7c9885 45%,
+          #5b8a9e 68%,
+          #4a6d9e 100%
+        );
+        position: relative;
+        overflow: hidden;
+        margin: 0.5rem 0;
+      }
+      .mural .icon {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        font-size: 0.8rem;
+        opacity: 0.85;
+      }
+      .mural .sel {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        background: rgba(255, 255, 255, 0.35);
+        border-left: 2px solid #fff;
+        border-right: 2px solid #fff;
+      }
+      /* radar */
+      .radar {
+        position: relative;
+        height: 70px;
+        border: 1.5px solid var(--line);
+        border-radius: 8px;
+        background: var(--card);
+        overflow: hidden;
+      }
+      .radar .pt {
+        position: absolute;
+        top: 50%;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--accent-mark);
+        transform: translate(-50%, -50%);
+      }
+      .radar .ring {
+        position: absolute;
+        top: 50%;
+        border: 2px dashed color-mix(in srgb, var(--accent-mark) 55%, transparent);
+        border-radius: 999px;
+        transform: translate(-50%, -50%);
+      }
+      table.cmp {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8rem;
+        margin-top: 1rem;
+      }
+      table.cmp th,
+      table.cmp td {
+        border: 1px solid var(--line);
+        padding: 0.4rem 0.55rem;
+        text-align: center;
+      }
+      table.cmp th {
+        background: color-mix(in srgb, var(--ink) 4%, transparent);
+        font-size: 0.8rem;
+        letter-spacing: 0.04em;
+      }
+      table.cmp td:first-child,
+      table.cmp th:first-child {
+        text-align: left;
+      }
+      .y {
+        color: var(--good);
+        font-weight: 700;
+      }
+      .n {
+        color: var(--bad);
+        font-weight: 700;
+      }
+      .p {
+        color: var(--warn);
+      }
+      section.verdict {
+        max-width: 74rem;
+        margin: 3rem auto 0;
+        padding: 1.5rem 1.25rem;
+        border-top: 3px solid var(--win);
+      }
+      section.verdict h2 {
+        font-size: 1.2rem;
+      }
+      code {
+        background: color-mix(in srgb, var(--ink) 6%, transparent);
+        padding: 0.05rem 0.3rem;
+        border-radius: 4px;
+        font-size: 0.85em;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="lab">
+      <h1>Classic Guess Entry - One-Gesture Range Control</h1>
+      <p class="sub">
+        Today's entry is two numeric text boxes plus two BC/AD segmented toggles - four controls for
+        one decision, defaulting to the historically nonexistent
+        <code>0 AD &rarr; 0 AD</code>, with width/points feedback that only updates on blur. This
+        lab holds 8 structurally distinct one-gesture mechanics for the common case (&ldquo;set a
+        range around a hunch year&rdquo;), each shown against the same scenario: a player who has a
+        hunch the answer is around the 1960s.
+      </p>
+      <div class="rule">
+        Fixed bars every option must clear: era stays 100% player-driven (no BC/AD inference from a
+        typed or dragged value - puzzle-integrity red line); width/points update live during
+        manipulation, not on blur/release; exact-year text entry survives as a fallback, not a full
+        replacement; nothing may cause the guess panel to change height mid-entry.
+      </div>
+    </header>
+
+    <nav class="toc">
+      <a href="#r1" class="win">R1 Winner</a>
+      <a href="#r2">R2</a><a href="#r3">R3</a><a href="#r4">R4</a><a href="#r5">R5</a>
+      <a href="#r6">R6</a><a href="#r7">R7</a><a href="#r8">R8</a><a href="#verdict">Verdict</a>
+    </nav>
+
+    <!-- R1 -->
+    <section class="opt" id="r1">
+      <div class="optcard">
+        <div class="opthead">
+          <h2>R1 - Drag-to-draw timeline bar <span class="winner-badge">Winner</span></h2>
+          <span class="tag">direct manipulation</span>
+        </div>
+        <div class="body">
+          <div class="mock">
+            <div class="ph">
+              <div class="brand">Classic</div>
+              <div class="card">
+                <div class="teach">Hint: One guess - drag the timeline to set your range</div>
+                <div class="bar">
+                  <div class="tick0" style="left: 37%"></div>
+                  <div class="fill" style="left: 52%; width: 14%"></div>
+                  <div class="handle" style="left: 52%"></div>
+                  <div class="handle" style="left: 66%"></div>
+                </div>
+                <div class="axis"><span>3000 BC</span><span>2026 AD</span></div>
+                <div class="readout">
+                  <span class="dim">64 of 250 years</span><span class="worth">✓ Worth 68 pts</span>
+                </div>
+                <div class="cta">Lock in final guess</div>
+                <div class="fallback">
+                  <span>Prefer exact years?</span><span>1958 → 2022 AD ▾</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="notes">
+            <h3>Structure</h3>
+            <ul>
+              <li>
+                Single pointer gesture directly on a bar spanning the puzzle's full
+                <code>MIN_YEAR..MAX_YEAR</code>: press sets an anchor, drag diverges the range live
+                from that anchor, release commits the draft. Same visual grammar as the results
+                screen's range bar (<code>RangeProximity</code>), now interactive.
+              </li>
+              <li>
+                Once a range exists, the two edge handles are independently drag- and
+                arrow-key-adjustable (<code>role="slider"</code>) for fine tuning without
+                re-drawing.
+              </li>
+              <li>
+                Exact-year text fields stay directly beneath, always present, visually secondary.
+              </li>
+            </ul>
+            <h3>For</h3>
+            <ul>
+              <li>
+                Literally one continuous gesture from "no range" to "a range around my hunch,"
+                anchored exactly where the player presses - not a fixed default point. Width/points
+                update every pointermove, not on blur. Reuses a visual object players already trust
+                from the results screen. Cheapest to make keyboard-accessible (handles are native
+                <code>slider</code> roles, arrow keys nudge ±1/±10).
+              </li>
+            </ul>
+            <h3>Against</h3>
+            <ul>
+              <li>
+                A ~5,000-year span compressed into one bar gives coarse initial placement (tens of
+                years per pixel) - fine, since the common case doesn't need pixel-perfect placement
+                and the handles/fallback cover precision.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- R2 -->
+    <section class="opt" id="r2">
+      <div class="optcard">
+        <div class="opthead">
+          <h2>R2 - Dual-thumb slider, pre-collapsed</h2>
+          <span class="tag">direct manipulation</span>
+        </div>
+        <div class="body">
+          <div class="mock">
+            <div class="ph">
+              <div class="brand">Classic</div>
+              <div class="card">
+                <div class="teach">Hint: Drag either dot to widen your range</div>
+                <div class="bar">
+                  <div class="tick0" style="left: 37%"></div>
+                  <div class="handle" style="left: 60%"></div>
+                  <div class="handle" style="left: 60%"></div>
+                </div>
+                <div class="axis"><span>3000 BC</span><span>2026 AD</span></div>
+                <div class="readout"><span class="dim">1 of 250 years</span><span></span></div>
+                <div class="cta" style="opacity: 0.4">Lock in final guess</div>
+              </div>
+            </div>
+          </div>
+          <div class="notes">
+            <h3>Structure</h3>
+            <ul>
+              <li>
+                Both thumbs start collapsed at a fixed default position (e.g. current year).
+                Dragging either thumb outward creates a range in one drag.
+              </li>
+            </ul>
+            <h3>For</h3>
+            <ul>
+              <li>
+                Familiar range-slider metaphor; can ride a library primitive (Radix Slider) instead
+                of hand-rolled pointer math.
+              </li>
+            </ul>
+            <h3>Against</h3>
+            <ul>
+              <li>
+                The default collapse point is arbitrary and rarely near the player's hunch year -
+                dragging one thumb from "current year" to "around 1500 AD" produces a 500-year
+                range, not a narrow one around the hunch. Fails "set a range around a hunch year" in
+                one gesture unless the player also repositions the whole pair first (two gestures).
+                Library's default click-nearest-thumb behavior doesn't natively support "draw fresh
+                from where I press," so it would need the same custom pointer logic as R1 anyway,
+                for a worse result.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- R3 -->
+    <section class="opt" id="r3">
+      <div class="optcard">
+        <div class="opthead">
+          <h2>R3 - Center-year number + width chips</h2>
+          <span class="tag">two-control combo</span>
+        </div>
+        <div class="body">
+          <div class="mock">
+            <div class="ph">
+              <div class="brand">Classic</div>
+              <div class="card">
+                <div class="teach">Hint: Set your hunch year, then pick a width</div>
+                <div
+                  style="text-align: center; font-size: 1.6rem; font-weight: 800; margin: 0.4rem 0"
+                >
+                  1969 AD
+                </div>
+                <div class="chips">
+                  <div class="chip">±5</div>
+                  <div class="chip sel">±10</div>
+                  <div class="chip">±25</div>
+                  <div class="chip">±50</div>
+                  <div class="chip">±125</div>
+                </div>
+                <div class="readout" style="margin-top: 0.5rem">
+                  <span class="dim">21 of 250 years</span><span class="worth">✓ Worth 92 pts</span>
+                </div>
+                <div class="cta">Lock in final guess</div>
+              </div>
+            </div>
+          </div>
+          <div class="notes">
+            <h3>Structure</h3>
+            <ul>
+              <li>
+                A big draggable/scrubbable center-year number (vertical drag or +/- steppers) paired
+                with a row of preset width chips (±5/±10/±25/±50/±125) that expand the range
+                symmetrically around it.
+              </li>
+            </ul>
+            <h3>For</h3>
+            <ul>
+              <li>
+                Extremely legible relationship between "how sure am I" (chip) and score; chips are
+                large, unambiguous tap targets, trivially keyboard-navigable.
+              </li>
+            </ul>
+            <h3>Against</h3>
+            <ul>
+              <li>
+                Two separate interactions for the common case (set center, then tap a width chip) -
+                doesn't clear the "one primary interaction" bar as cleanly as R1. Symmetric-only
+                widths also can't express "I'm sure about the early bound but not the late one,"
+                which R1's independent handles can.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- R4 -->
+    <section class="opt" id="r4">
+      <div class="optcard">
+        <div class="opthead">
+          <h2>R4 - Tap-to-anchor + scroll/pinch-to-widen</h2>
+          <span class="tag">gesture combo</span>
+        </div>
+        <div class="body">
+          <div class="mock">
+            <div class="ph">
+              <div class="brand">Classic</div>
+              <div class="card">
+                <div class="teach">Hint: Tap your hunch year, then pinch to widen</div>
+                <div class="radar">
+                  <div class="ring" style="left: 60%; width: 70px; height: 70px"></div>
+                  <div class="pt" style="left: 60%"></div>
+                </div>
+                <div class="readout" style="margin-top: 0.5rem">
+                  <span class="dim">64 of 250 years</span><span class="worth">✓ Worth 68 pts</span>
+                </div>
+                <div class="cta">Lock in final guess</div>
+              </div>
+            </div>
+          </div>
+          <div class="notes">
+            <h3>Structure</h3>
+            <ul>
+              <li>
+                A tap plants a center pin; a trackpad/wheel scroll (desktop) or two-finger pinch
+                (touch) inflates a symmetric width ring around it, mirroring photo-zoom gestures.
+              </li>
+            </ul>
+            <h3>For</h3>
+            <ul>
+              <li>Novel, tactile, and genuinely "one gesture" once the pin is down.</li>
+            </ul>
+            <h3>Against</h3>
+            <ul>
+              <li>
+                Pinch has no direct keyboard or single-pointer-mouse equivalent (mouse users are
+                stuck with scroll-to-widen, which conflicts with page scroll and needs careful event
+                capture); accessibility story is materially worse than a slider with native
+                <code>role="slider"</code> handles. Two-stage gesture (tap, then a second distinct
+                gesture) reads as two interactions in practice even if fast.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- R5 -->
+    <section class="opt" id="r5">
+      <div class="optcard">
+        <div class="opthead">
+          <h2>R5 - Rubber-band radius from a point</h2>
+          <span class="tag">direct manipulation</span>
+        </div>
+        <div class="body">
+          <div class="mock">
+            <div class="ph">
+              <div class="brand">Classic</div>
+              <div class="card">
+                <div class="teach">Hint: Press your hunch year, drag out to widen</div>
+                <div class="radar">
+                  <div class="ring" style="left: 45%; width: 96px; height: 96px"></div>
+                  <div class="pt" style="left: 45%"></div>
+                </div>
+                <div class="readout" style="margin-top: 0.5rem">
+                  <span class="dim">64 of 250 years</span><span class="worth">✓ Worth 68 pts</span>
+                </div>
+                <div class="cta">Lock in final guess</div>
+              </div>
+            </div>
+          </div>
+          <div class="notes">
+            <h3>Structure</h3>
+            <ul>
+              <li>
+                Press-and-hold on a point, drag vertically (away from the timeline) to inflate an
+                expanding "confidence radius" pill around the pressed year; horizontal position of
+                the drag is ignored, only distance from the press point matters.
+              </li>
+            </ul>
+            <h3>For</h3>
+            <ul>
+              <li>
+                One continuous press-drag-release, same as R1, but visually distinct (radar/target
+                metaphor) and always symmetric.
+              </li>
+            </ul>
+            <h3>Against</h3>
+            <ul>
+              <li>
+                Symmetric-only (can't express asymmetric confidence); the radius-to-years mapping
+                needs an arbitrary sensitivity curve that's harder to reason about than "drag along
+                the actual timeline" (R1's drag distance IS the year distance, 1:1 legible); a
+                circular/radial visual is a bigger departure from the results screen's linear bar
+                than the card's own hint calls for.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- R6 -->
+    <section class="opt" id="r6">
+      <div class="optcard">
+        <div class="opthead">
+          <h2>R6 - Rotary dial</h2>
+          <span class="tag">novel control</span>
+        </div>
+        <div class="body">
+          <div class="mock">
+            <div class="ph">
+              <div class="brand">Classic</div>
+              <div class="card">
+                <div class="teach">Hint: Rotate to your hunch year, spread to widen</div>
+                <div class="dial">
+                  <div class="nub"></div>
+                  <div class="center"><b>1969</b><span>AD</span></div>
+                </div>
+                <div class="readout">
+                  <span class="dim">64 of 250 years</span><span class="worth">✓ Worth 68 pts</span>
+                </div>
+                <div class="cta">Lock in final guess</div>
+              </div>
+            </div>
+          </div>
+          <div class="notes">
+            <h3>Structure</h3>
+            <ul>
+              <li>
+                A circular dial where rotation scrubs the center year (non-linear velocity gives
+                fine control near small movements, coarse control on fast spins); a second
+                concentric ring, dragged outward, sets width.
+              </li>
+            </ul>
+            <h3>For</h3>
+            <ul>
+              <li>
+                Solves the precision-vs-span problem elegantly via rotational velocity sensitivity -
+                the same trick date-of-birth pickers use.
+              </li>
+            </ul>
+            <h3>Against</h3>
+            <ul>
+              <li>
+                Highest implementation and testing cost of the eight (custom rotation math, two
+                nested gesture zones, no native ARIA role fits a two-axis dial); least discoverable
+                metaphor for "guess a year"; keyboard equivalence would need to be invented from
+                scratch. Biggest departure from the results-screen bar, working against visual
+                continuity.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- R7 -->
+    <section class="opt" id="r7">
+      <div class="optcard">
+        <div class="opthead">
+          <h2>R7 - Momentum scrub wheel + width chips</h2>
+          <span class="tag">two-control combo</span>
+        </div>
+        <div class="body">
+          <div class="mock">
+            <div class="ph">
+              <div class="brand">Classic</div>
+              <div class="card">
+                <div class="teach">Hint: Flick to your hunch year</div>
+                <div class="wheel">
+                  <div class="row">1966</div>
+                  <div class="row">1967</div>
+                  <div class="row">1968</div>
+                  <div class="row sel">1969</div>
+                  <div class="row">1970</div>
+                  <div class="row">1971</div>
+                  <div class="row">1972</div>
+                </div>
+                <div class="chips" style="margin-top: 0.5rem">
+                  <div class="chip">±5</div>
+                  <div class="chip sel">±10</div>
+                  <div class="chip">±25</div>
+                </div>
+                <div class="cta" style="margin-top: 0.5rem">Lock in final guess</div>
+              </div>
+            </div>
+          </div>
+          <div class="notes">
+            <h3>Structure</h3>
+            <ul>
+              <li>
+                An iOS-style spinning reel of years: flick with momentum/inertia to land near the
+                hunch year (full span addressable, fine control from deceleration), paired with
+                width chips like R3.
+              </li>
+            </ul>
+            <h3>For</h3>
+            <ul>
+              <li>
+                Momentum scrubbing is a proven mobile-native pattern (date/time pickers) and gives
+                good precision across a huge span without a non-linear scale.
+              </li>
+            </ul>
+            <h3>Against</h3>
+            <ul>
+              <li>
+                Desktop/mouse users get a much worse version of this gesture (no native "flick"
+                outside touch); still two stages (scrub, then tap a chip) like R3; a
+                spinning-numbers wheel is the least visually connected to the results screen's range
+                bar.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- R8 -->
+    <section class="opt" id="r8">
+      <div class="optcard">
+        <div class="opthead">
+          <h2>R8 - Illustrated era-mural drag-select</h2>
+          <span class="tag">direct manipulation</span>
+        </div>
+        <div class="body">
+          <div class="mock">
+            <div class="ph">
+              <div class="brand">Classic</div>
+              <div class="card">
+                <div class="teach">Hint: Drag across the eras to set your range</div>
+                <div class="mural">
+                  <span class="icon" style="left: 8%">Ancient</span>
+                  <span class="icon" style="left: 28%">Classical</span>
+                  <span class="icon" style="left: 48%">Medieval</span>
+                  <span class="icon" style="left: 68%">Industrial</span>
+                  <span class="icon" style="left: 86%">Modern</span>
+                  <div class="sel" style="left: 70%; width: 16%"></div>
+                </div>
+                <div class="axis"><span>3000 BC</span><span>2026 AD</span></div>
+                <div class="readout">
+                  <span class="dim">64 of 250 years</span><span class="worth">✓ Worth 68 pts</span>
+                </div>
+                <div class="cta">Lock in final guess</div>
+              </div>
+            </div>
+          </div>
+          <div class="notes">
+            <h3>Structure</h3>
+            <ul>
+              <li>
+                Same press-drag-release gesture as R1, but the flat bar is replaced with an
+                illustrated horizontal "mural" (pyramids → classical → medieval → industrial →
+                modern icons) for spatial/historical intuition instead of raw numbers.
+              </li>
+            </ul>
+            <h3>For</h3>
+            <ul>
+              <li>
+                Richer at-a-glance context for where a drag lands relative to eras a player already
+                thinks in.
+              </li>
+            </ul>
+            <h3>Against</h3>
+            <ul>
+              <li>
+                Icon placement itself is a soft era cue baked into a fixed, answer-independent
+                scale, so it's puzzle-integrity-safe - but it adds real asset/illustration scope
+                (icon set, licensing, dark-mode variants) for a decorative layer over R1's identical
+                interaction model. Same gesture, same math, strictly more to build and maintain for
+                a marginal legibility gain.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ========================= VERDICT ========================= -->
+
+    <section class="verdict" id="verdict">
+      <h2>Verdict</h2>
+      <p>
+        <b
+          >R1 - drag-to-draw timeline bar, with independently draggable/keyboard-adjustable edge
+          handles and the exact-year fields retained underneath.</b
+        >
+        It is the only option that turns "no range" into "a valid range around my hunch" in one
+        continuous, standard, well-understood gesture (press-drag-release, the same grammar as
+        selecting text or a calendar date range) anchored exactly where the player presses - not at
+        an arbitrary fixed point (R2's failure) and not split across two distinct gestures (R3, R4,
+        R7's failure). It reuses the exact visual object the results screen already renders
+        (<code>RangeProximity</code>'s bar), satisfying the card's request for that object to become
+        interactive. Its accessibility story is the cheapest to build correctly: the post-drag
+        handles are native <code>role="slider"</code> elements with ordinary arrow-key semantics, no
+        bespoke gesture (pinch, rotation, momentum-flick) needs an invented keyboard or
+        screen-reader equivalent. Width/points recompute on every <code>pointermove</code>,
+        satisfying the live-feedback bar directly. R8 is the closest runner-up - same interaction,
+        better spatial storytelling - but is strictly more to build (an era icon set, dark-mode
+        variants) for a decorative gain that doesn't change the interaction bars; worth revisiting
+        once the base control has shipped and proven itself.
+      </p>
+      <table class="cmp">
+        <tr>
+          <th></th>
+          <th>one continuous gesture</th>
+          <th>anchored at press point (not fixed default)</th>
+          <th>live feedback while dragging</th>
+          <th>keyboard-native handles</th>
+          <th>reuses results-screen bar</th>
+          <th>build cost</th>
+        </tr>
+        <tr>
+          <td><b>R1 ★</b></td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="y">low</td>
+        </tr>
+        <tr>
+          <td>R2</td>
+          <td class="p">1 drag, wrong anchor</td>
+          <td class="n">✗ fixed point</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="y">low</td>
+        </tr>
+        <tr>
+          <td>R3</td>
+          <td class="n">2 stages</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="n">✗</td>
+          <td class="p">medium</td>
+        </tr>
+        <tr>
+          <td>R4</td>
+          <td class="n">2 stages</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="n">✗ no kb</td>
+          <td class="n">✗</td>
+          <td class="p">medium</td>
+        </tr>
+        <tr>
+          <td>R5</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="p">custom</td>
+          <td class="n">✗</td>
+          <td class="p">medium</td>
+        </tr>
+        <tr>
+          <td>R6</td>
+          <td class="p">2 zones</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="n">✗ invented</td>
+          <td class="n">✗</td>
+          <td class="n">high</td>
+        </tr>
+        <tr>
+          <td>R7</td>
+          <td class="n">2 stages</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="p">touch-biased</td>
+          <td class="n">✗</td>
+          <td class="p">medium</td>
+        </tr>
+        <tr>
+          <td>R8</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="y">✓</td>
+          <td class="p">reskinned</td>
+          <td class="p">medium+assets</td>
+        </tr>
+      </table>
+      <p class="sub" style="margin-bottom: 0">
+        Implementation: new <code>TimelineRangeBar.tsx</code> (pointer-drag + keyboard-adjustable
+        dual handles, no new dependency) composed into <code>RangeInput.tsx</code> as the primary
+        control; the existing numeric FROM/TO + era-toggle fields stay mounted, unchanged
+        internally, directly beneath as the exact-entry fallback (so every existing e2e/unit path
+        that drives them keeps working). The layout-shift bug is fixed by deleting the onboarding
+        banner that mounted/unmounted above the card and folding its "one guess" teaching copy into
+        the panel's existing fixed-height status row instead of a separate block. Default state
+        changes from a fake <code>0 AD → 0 AD</code> to a genuinely empty, un-set range. Post-submit
+        focus moves to the results heading via a <code>tabIndex=-1</code> ref in
+        <code>GameLayout</code>.
+      </p>
+    </section>
+  </body>
+</html>

--- a/e2e/classic-range-entry.spec.ts
+++ b/e2e/classic-range-entry.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Targeted E2E coverage for the Classic range-entry redesign
+ * (chrondle-ux-range-entry): the drag-to-draw timeline bar as the primary
+ * one-gesture control, live width/points feedback during manipulation, zero
+ * layout shift while entering a guess, the one-shot mechanic taught before
+ * the first lock-in, the exact-year fields retained as a fallback, and
+ * focus landing on the results summary after submit.
+ *
+ * Tagged with @happy-path for CI filtering, matching game-flow.spec.ts.
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+async function goToClassicGame(page: Page) {
+  await page.goto("/classic", { waitUntil: "domcontentloaded" });
+  await expect(page.getByText("Primary Clue")).toBeVisible({ timeout: 10000 });
+}
+
+/** Drag the timeline track from one fractional position to another. */
+async function dragTimeline(page: Page, fromFraction: number, toFraction: number) {
+  const track = page.getByTestId("timeline-range-track");
+  await track.scrollIntoViewIfNeeded();
+  await expect(track).toBeVisible();
+  const box = await track.boundingBox();
+  if (!box) throw new Error("timeline-range-track has no bounding box");
+
+  const y = box.y + box.height / 2;
+  const fromX = box.x + box.width * fromFraction;
+  const toX = box.x + box.width * toFraction;
+
+  await page.mouse.move(fromX, y);
+  await page.mouse.down();
+  await page.mouse.move(toX, y, { steps: 8 });
+  return { toX, y, up: () => page.mouse.up() };
+}
+
+test.describe("Classic range entry - one-gesture timeline @happy-path", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test("teaches the one-shot mechanic before the first interaction", async ({ page }) => {
+    await goToClassicGame(page);
+
+    // Copy exists before the player has touched anything - the acceptance
+    // bar is "taught before the first lock-in", not just implied by the CTA.
+    await expect(page.getByText(/one guess.*drag/i)).toBeVisible();
+    await expect(page.getByTestId("timeline-handle-start")).not.toBeVisible();
+    await expect(page.getByTestId("timeline-handle-end")).not.toBeVisible();
+  });
+
+  test("drawing a range on the timeline shows live width/points feedback before release", async ({
+    page,
+  }) => {
+    await goToClassicGame(page);
+
+    const drag = await dragTimeline(page, 0.55, 0.59);
+
+    // Still mid-drag - the pointer button hasn't been released yet - so
+    // this proves the readout updates on every move, not on blur/release.
+    await expect(page.getByText(/\d+\s+of\s+250\s+years/i)).toBeVisible();
+    const exceedsOrWorth = page.getByText(/exceeds limit|worth\s+\d+\s+pts if right/i);
+    await expect(exceedsOrWorth).toBeVisible();
+
+    await drag.up();
+  });
+
+  test("keeps the exact-year fields visible as a fallback beside the timeline", async ({
+    page,
+  }) => {
+    await goToClassicGame(page);
+
+    await expect(page.getByTestId("timeline-range-track")).toBeVisible();
+    await expect(page.getByText(/prefer exact years/i)).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Start year" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "End year" })).toBeVisible();
+  });
+
+  test("causes no measurable layout shift while dragging and typing", async ({ page }) => {
+    await goToClassicGame(page);
+    await expect(page.getByTestId("timeline-range-track")).toBeVisible();
+
+    // Measure only the interaction window, not initial page load (fonts/
+    // images loading in can shift layout independent of this component).
+    await page.evaluate(() => {
+      const win = window as typeof window & { __clsValue: number };
+      win.__clsValue = 0;
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          const shift = entry as unknown as { hadRecentInput: boolean; value: number };
+          if (!shift.hadRecentInput) win.__clsValue += shift.value;
+        }
+      });
+      observer.observe({ type: "layout-shift", buffered: false });
+    });
+
+    const drag = await dragTimeline(page, 0.55, 0.59);
+    await drag.up();
+
+    const startYearInput = page.getByRole("textbox", { name: "Start year" });
+    await startYearInput.click();
+    await startYearInput.fill("1500");
+    await startYearInput.blur();
+
+    const cls = await page.evaluate(
+      () => (window as typeof window & { __clsValue: number }).__clsValue,
+    );
+    expect(cls).toBeLessThan(0.05);
+  });
+
+  test("moves focus to the results summary after locking in a guess", async ({ page }) => {
+    await goToClassicGame(page);
+
+    const drag = await dragTimeline(page, 0.55, 0.59);
+    await drag.up();
+
+    const submitButton = page.getByRole("button", { name: /lock in|submit range/i });
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await expect(page.getByTestId("results-focus-anchor")).toBeFocused({ timeout: 10000 });
+  });
+});

--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { GameInstructions } from "@/components/GameInstructions";
 import { KeepPlaying } from "@/components/KeepPlaying";
 import { RangeInput } from "@/components/game/RangeInput";
@@ -143,6 +143,19 @@ export function GameLayout(props: GameLayoutProps) {
     });
   };
 
+  // After the one-shot guess is locked in, move focus to the results
+  // summary - the next useful continuation point once RangeInput itself
+  // unmounts. tabIndex=-1 makes the wrapper programmatically focusable
+  // without adding it to the tab order.
+  const resultsRef = useRef<HTMLDivElement>(null);
+  const wasGameComplete = useRef(isGameComplete);
+  useEffect(() => {
+    if (isGameComplete && !wasGameComplete.current) {
+      resultsRef.current?.focus();
+    }
+    wasGameComplete.current = isGameComplete;
+  }, [isGameComplete]);
+
   return (
     <div className="bg-background flex flex-1 flex-col">
       {/* Optional header content */}
@@ -275,15 +288,22 @@ export function GameLayout(props: GameLayoutProps) {
           {/* Game Complete Summary */}
           {isGameComplete && (
             <>
-              <GameComplete
-                ranges={gameState.ranges}
-                totalScore={totalScore}
-                hasWon={hasWon}
-                puzzleNumber={puzzleNumber}
-                targetYear={targetYear}
-                totalHints={gameState.puzzle?.events.length}
-                events={gameState.puzzle?.events}
-              />
+              <div
+                ref={resultsRef}
+                tabIndex={-1}
+                data-testid="results-focus-anchor"
+                className="outline-none"
+              >
+                <GameComplete
+                  ranges={gameState.ranges}
+                  totalScore={totalScore}
+                  hasWon={hasWon}
+                  puzzleNumber={puzzleNumber}
+                  targetYear={targetYear}
+                  totalHints={gameState.puzzle?.events.length}
+                  events={gameState.puzzle?.events}
+                />
+              </div>
               <KeepPlaying currentMode="classic" />
             </>
           )}

--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 import { GameInstructions } from "@/components/GameInstructions";
 import { KeepPlaying } from "@/components/KeepPlaying";
-import { RangeInput } from "@/components/game/RangeInput";
 import { HintIndicator } from "@/components/game/HintIndicator";
 import { Confetti, ConfettiRef } from "@/components/magicui/confetti";
 import { GameComplete } from "@/components/modals/GameComplete";
@@ -11,6 +11,15 @@ import { validateGameLayoutProps } from "@/lib/propValidation";
 import { motion } from "motion/react";
 import { cn, seededRandom } from "@/lib/utils";
 import type { RangeGuess } from "@/types/range";
+
+// The classic range input is rendered by three routes (home, /classic,
+// /archive/puzzle/[id]). Pulling it through one dynamic boundary keeps it in a
+// single shared chunk instead of being inlined into each route bundle. SSR is
+// preserved (default), so the input is server-rendered with no loading flash.
+const RangeInput = dynamic(
+  () => import("@/components/game/RangeInput").then((m) => ({ default: m.RangeInput })),
+  { ssr: true },
+);
 
 export interface GameLayoutProps {
   // Core game state

--- a/src/components/__tests__/GameLayout.test.tsx
+++ b/src/components/__tests__/GameLayout.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { GameLayout, type GameLayoutProps } from "../GameLayout";
 import { validateGameLayoutProps } from "@/lib/propValidation";
 
@@ -168,6 +168,29 @@ describe("GameLayout", () => {
 
       fireEvent.click(screen.getByTestId("range-input"));
       expect(mockOnRangeCommit).toHaveBeenCalledWith({ start: 1900, end: 1950, hintsUsed: 0 });
+    });
+
+    it("moves focus to the results summary once the game transitions to complete", async () => {
+      const props = createDefaultProps();
+      const { rerender } = render(<GameLayout {...props} />);
+
+      // Not focused while still active.
+      expect(screen.queryByTestId("results-focus-anchor")).not.toBeInTheDocument();
+
+      rerender(<GameLayout {...props} isGameComplete />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("results-focus-anchor")).toHaveFocus();
+      });
+    });
+
+    it("does not steal focus on initial mount when already complete", () => {
+      const props = createDefaultProps();
+      props.isGameComplete = true;
+
+      render(<GameLayout {...props} />);
+
+      expect(screen.getByTestId("results-focus-anchor")).not.toHaveFocus();
     });
   });
 

--- a/src/components/__tests__/GameLayout.test.tsx
+++ b/src/components/__tests__/GameLayout.test.tsx
@@ -110,12 +110,14 @@ describe("GameLayout", () => {
   });
 
   describe("required props", () => {
-    it("renders primary sections", () => {
+    it("renders primary sections", async () => {
       const props = createDefaultProps();
       render(<GameLayout {...props} />);
 
       expect(screen.getByTestId("game-instructions")).toBeTruthy();
-      expect(screen.getByTestId("range-input")).toBeTruthy();
+      // RangeInput loads through a next/dynamic boundary (shared chunk), so it
+      // resolves asynchronously in the test environment.
+      expect(await screen.findByTestId("range-input")).toBeTruthy();
       expect(screen.getByTestId("hint-indicator")).toBeTruthy();
     });
 

--- a/src/components/game/RangeInput.tsx
+++ b/src/components/game/RangeInput.tsx
@@ -5,6 +5,7 @@ import { motion } from "motion/react";
 import { Lightbulb } from "@/components/kit/icons";
 import { Button } from "@/components/ui/button";
 import { EraToggle } from "@/components/kit/EraToggle";
+import { TimelineRangeBar } from "@/components/game/TimelineRangeBar";
 import { SCORING_CONSTANTS, computeScoreBreakdown } from "@/lib/scoring";
 import { GAME_CONFIG } from "@/lib/constants";
 import { convertToInternalYear, convertFromInternalYear, type Era } from "@/lib/eraUtils";
@@ -26,10 +27,9 @@ interface RangeInputProps {
 }
 
 /**
- * Creates default range spanning the full timeline
- * This forces user to modify before submitting
+ * Creates the internal unset sentinel. It is never displayed as a real year.
  */
-function createFullTimelineRange(_minYear: number, _maxYear: number): [number, number] {
+function createUnsetRange(_minYear: number, _maxYear: number): [number, number] {
   return [0, 0];
 }
 
@@ -61,6 +61,22 @@ function createDraftState(
   range: [number, number],
   hasBeenModified: boolean = false,
 ): RangeDraftState {
+  // Before the player has actually set a range, show empty fields rather
+  // than a fake year. The internal sentinel range is never a real guess;
+  // it exists only so downstream width/score math always has two numbers.
+  if (!hasBeenModified) {
+    return {
+      syncedRangeKey: getRangeKey(range),
+      startInput: "",
+      endInput: "",
+      startEra: "AD",
+      endEra: "AD",
+      startError: null,
+      endError: null,
+      hasBeenModified: false,
+    };
+  }
+
   const start = convertFromInternalYear(range[0]);
   const end = convertFromInternalYear(range[1]);
 
@@ -72,7 +88,7 @@ function createDraftState(
     endEra: end.era,
     startError: null,
     endError: null,
-    hasBeenModified,
+    hasBeenModified: true,
   };
 }
 
@@ -88,7 +104,7 @@ export function RangeInput({
   onChange,
 }: RangeInputProps) {
   const prefersReducedMotion = useReducedMotion();
-  const defaultRange = useMemo(() => createFullTimelineRange(minYear, maxYear), [minYear, maxYear]);
+  const defaultRange = useMemo(() => createUnsetRange(minYear, maxYear), [minYear, maxYear]);
   const boundsKey = useMemo(() => getBoundsKey(minYear, maxYear), [minYear, maxYear]);
   const isControlled = value !== undefined && onChange !== undefined;
   const [internalRangeState, setInternalRangeState] = useState<InternalRangeState>(() => ({
@@ -120,7 +136,9 @@ export function RangeInput({
   const width = range[1] - range[0] + 1;
   const rangeTooWide = width > SCORING_CONSTANTS.W_MAX;
   const commitDisabled = disabled || rangeTooWide || !hasBeenModified;
-  const progressPercent = Math.min((width / SCORING_CONSTANTS.W_MAX) * 100, 100);
+  const progressPercent = hasBeenModified
+    ? Math.min((width / SCORING_CONSTANTS.W_MAX) * 100, 100)
+    : 0;
 
   // Live risk/reward readout: what this range pays if it contains the answer.
   // Reacts to both width changes and hints taken, using the real curve.
@@ -135,17 +153,38 @@ export function RangeInput({
   }, [range, rangeTooWide, clampedHints]);
 
   const resetRange = useCallback(() => {
-    const nextRange = createFullTimelineRange(minYear, maxYear);
+    const nextRange = createUnsetRange(minYear, maxYear);
     updateRange(nextRange);
     setDraftState(createDraftState(nextRange));
   }, [minYear, maxYear, updateRange]);
+
+  // Primary one-gesture path: the timeline bar reports live years while the
+  // player drags, sharing the same range/draft state as the fallback text
+  // fields below so either path keeps the other in sync.
+  const handleBarChange = useCallback(
+    (nextRange: [number, number]) => {
+      updateRange(nextRange);
+      setDraftState(createDraftState(nextRange, true));
+    },
+    [updateRange],
+  );
+
+  const buildRangeFromStart = (internalYear: number): [number, number] => {
+    if (!hasBeenModified) return [internalYear, internalYear];
+    return [internalYear, Math.max(internalYear, range[1])];
+  };
+
+  const buildRangeFromEnd = (internalYear: number): [number, number] => {
+    if (!hasBeenModified) return [internalYear, internalYear];
+    return [Math.min(range[0], internalYear), internalYear];
+  };
 
   const handleStartEraChange = (era: Era) => {
     const parsed = parseInt(startInput, 10);
     if (!Number.isNaN(parsed)) {
       const internalYear = convertToInternalYear(parsed, era);
       if (internalYear >= minYear && internalYear <= maxYear) {
-        const nextRange: [number, number] = [internalYear, Math.max(internalYear, range[1])];
+        const nextRange = buildRangeFromStart(internalYear);
         updateRange(nextRange);
         setDraftState(createDraftState(nextRange, true));
         return;
@@ -163,7 +202,7 @@ export function RangeInput({
     if (!Number.isNaN(parsed)) {
       const internalYear = convertToInternalYear(parsed, era);
       if (internalYear >= minYear && internalYear <= maxYear) {
-        const nextRange: [number, number] = [Math.min(range[0], internalYear), internalYear];
+        const nextRange = buildRangeFromEnd(internalYear);
         updateRange(nextRange);
         setDraftState(createDraftState(nextRange, true));
         return;
@@ -181,7 +220,7 @@ export function RangeInput({
     if (!Number.isNaN(parsed) && parsed > 0) {
       const internalYear = convertToInternalYear(parsed, startEra);
       if (internalYear >= minYear && internalYear <= maxYear) {
-        const nextRange: [number, number] = [internalYear, Math.max(internalYear, range[1])];
+        const nextRange = buildRangeFromStart(internalYear);
         updateRange(nextRange);
         setDraftState(createDraftState(nextRange, true));
       } else {
@@ -191,7 +230,13 @@ export function RangeInput({
         });
       }
     } else if (startInput.trim() === "") {
-      // Empty input - reset silently
+      // Empty input - reset silently. Before a real range exists there is
+      // nothing to fall back to, so stay empty rather than surfacing the
+      // internal sentinel as a fake year.
+      if (!hasBeenModified) {
+        setDraftState({ ...draft, startInput: "", startError: null });
+        return;
+      }
       const current = convertFromInternalYear(range[0]);
       setDraftState({
         ...draft,
@@ -212,7 +257,7 @@ export function RangeInput({
     if (!Number.isNaN(parsed) && parsed > 0) {
       const internalYear = convertToInternalYear(parsed, endEra);
       if (internalYear >= minYear && internalYear <= maxYear) {
-        const nextRange: [number, number] = [Math.min(range[0], internalYear), internalYear];
+        const nextRange = buildRangeFromEnd(internalYear);
         updateRange(nextRange);
         setDraftState(createDraftState(nextRange, true));
       } else {
@@ -222,7 +267,13 @@ export function RangeInput({
         });
       }
     } else if (endInput.trim() === "") {
-      // Empty input - reset silently
+      // Empty input - reset silently. Before a real range exists there is
+      // nothing to fall back to, so stay empty rather than surfacing the
+      // internal sentinel as a fake year.
+      if (!hasBeenModified) {
+        setDraftState({ ...draft, endInput: "", endError: null });
+        return;
+      }
       const current = convertFromInternalYear(range[1]);
       setDraftState({
         ...draft,
@@ -263,16 +314,6 @@ export function RangeInput({
 
   return (
     <div className={cn("space-y-6", className)}>
-      {/* Onboarding message for first-time users */}
-      {!hasBeenModified && !disabled && (
-        <div className="border-feedback-success bg-feedback-success/10 dark:bg-feedback-success/20 rounded border px-4 py-3">
-          <p className="text-feedback-success flex items-center gap-2 text-sm font-medium">
-            <Lightbulb className="h-4 w-4 shrink-0" aria-hidden="true" />
-            Adjust the years to narrow your range, then submit your guess
-          </p>
-        </div>
-      )}
-
       {/* Ledger Entry Card */}
       <div
         className={cn(
@@ -297,14 +338,37 @@ export function RangeInput({
               Range
             </span>
             <span className="text-body-primary font-mono text-sm font-semibold tabular-nums">
-              {formatYearDisplay(range[0])}
-              <span className="text-muted-foreground mx-2">→</span>
-              {formatYearDisplay(range[1])}
+              {hasBeenModified ? (
+                <>
+                  {formatYearDisplay(range[0])}
+                  <span className="text-muted-foreground mx-2">→</span>
+                  {formatYearDisplay(range[1])}
+                </>
+              ) : (
+                <span className="text-muted-foreground font-normal">Not set yet</span>
+              )}
             </span>
           </div>
         </div>
 
-        {/* Input Controls - Ledger Style */}
+        {/* Primary control: drag the timeline to draw a range in one gesture */}
+        <div className="mb-6">
+          <TimelineRangeBar
+            minYear={minYear}
+            maxYear={maxYear}
+            value={range}
+            hasValue={hasBeenModified}
+            onChange={handleBarChange}
+            disabled={disabled}
+          />
+        </div>
+
+        {/* Input Controls - Ledger Style (exact-year fallback) */}
+        <div className="mb-3">
+          <span className="text-muted-foreground text-[10px] font-bold tracking-[0.15em] uppercase">
+            Prefer exact years?
+          </span>
+        </div>
         <div className="flex flex-col gap-8 sm:flex-row sm:items-end sm:gap-12">
           {/* Start Year Group */}
           <div className="flex-1">
@@ -320,6 +384,7 @@ export function RangeInput({
                   id="start-year"
                   type="text"
                   inputMode="numeric"
+                  placeholder="Year"
                   value={startInput}
                   onChange={(e) => {
                     setDraftState({
@@ -332,7 +397,7 @@ export function RangeInput({
                   onKeyDown={(e) => handleInputKeyDown(e, applyStartYear)}
                   disabled={disabled}
                   className={cn(
-                    "ledger-entry-line w-full px-2 pt-1 pb-2 text-center font-mono text-3xl font-semibold tabular-nums",
+                    "ledger-entry-line w-full px-2 pt-1 pb-2 text-center font-mono text-xl font-semibold tabular-nums",
                     "text-body-primary placeholder:text-muted-foreground/50",
                     "disabled:cursor-not-allowed disabled:opacity-50",
                     startError && "border-feedback-error text-feedback-error border-b-2",
@@ -380,6 +445,7 @@ export function RangeInput({
                   id="end-year"
                   type="text"
                   inputMode="numeric"
+                  placeholder="Year"
                   value={endInput}
                   onChange={(e) => {
                     setDraftState({
@@ -392,7 +458,7 @@ export function RangeInput({
                   onKeyDown={(e) => handleInputKeyDown(e, applyEndYear)}
                   disabled={disabled}
                   className={cn(
-                    "ledger-entry-line w-full px-2 pt-1 pb-2 text-center font-mono text-3xl font-semibold tabular-nums",
+                    "ledger-entry-line w-full px-2 pt-1 pb-2 text-center font-mono text-xl font-semibold tabular-nums",
                     "text-body-primary placeholder:text-muted-foreground/50",
                     "disabled:cursor-not-allowed disabled:opacity-50",
                     endError && "border-feedback-error text-feedback-error border-b-2",
@@ -436,10 +502,24 @@ export function RangeInput({
             />
           </div>
 
-          {/* Validation Status */}
-          <div className="flex items-center justify-between">
-            <span className="text-muted-foreground font-mono text-xs tabular-nums">
-              {width.toLocaleString()} of {SCORING_CONSTANTS.W_MAX.toLocaleString()} years
+          {/* Validation Status - a single fixed-height slot that teaches the
+              one-shot mechanic before the range is set, then swaps to the
+              live width readout. Text-only swap (never a mount/unmount of
+              this row) so the guess panel never reflows mid-entry. */}
+          <div className="flex min-h-[1.25rem] items-center justify-between gap-3">
+            <span className="text-muted-foreground flex items-center gap-1.5 font-mono text-xs tabular-nums">
+              {hasBeenModified ? (
+                <>
+                  {width.toLocaleString()} of {SCORING_CONSTANTS.W_MAX.toLocaleString()} years
+                </>
+              ) : (
+                <>
+                  <Lightbulb className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  {isOneGuessMode
+                    ? "One guess: drag to set your range"
+                    : "Drag the timeline to set your range"}
+                </>
+              )}
             </span>
 
             {rangeTooWide ? (

--- a/src/components/game/TimelineRangeBar.tsx
+++ b/src/components/game/TimelineRangeBar.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import React, { useCallback, useRef, useState } from "react";
-import { cn } from "@/lib/utils";
-import { formatYear } from "@/lib/displayFormatting";
+import { useCallback, useRef, useState } from "react";
 
 type DragTarget = "start" | "end" | "new" | null;
 
@@ -23,6 +21,10 @@ export interface TimelineRangeBarProps {
 
 const FINE_STEP = 1;
 const COARSE_STEP = 10;
+
+function formatTimelineYear(year: number): string {
+  return year < 0 ? `${Math.abs(year)} BC` : `${year} AD`;
+}
 
 /**
  * A single-gesture range picker: press-drag-release directly on the timeline
@@ -151,7 +153,7 @@ export function TimelineRangeBar({
   const showZeroTick = minYear < 0 && maxYear > 0;
 
   return (
-    <div className={cn("space-y-1.5", className)}>
+    <div className={className ? `space-y-1.5 ${className}` : "space-y-1.5"}>
       <div
         ref={trackRef}
         onPointerDown={handleTrackPointerDown}
@@ -159,10 +161,9 @@ export function TimelineRangeBar({
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
         data-testid="timeline-range-track"
-        className={cn(
-          "bg-muted/60 relative h-11 touch-none rounded-full transition-colors select-none",
-          disabled ? "cursor-not-allowed opacity-50" : "hover:bg-muted/80 cursor-crosshair",
-        )}
+        className={`bg-muted/60 relative h-11 touch-none rounded-full transition-colors select-none ${
+          disabled ? "cursor-not-allowed opacity-50" : "hover:bg-muted/80 cursor-crosshair"
+        }`}
       >
         {showZeroTick && (
           <div
@@ -192,7 +193,7 @@ export function TimelineRangeBar({
               aria-valuemin={minYear}
               aria-valuemax={value[1]}
               aria-valuenow={value[0]}
-              aria-valuetext={formatYear(value[0])}
+              aria-valuetext={formatTimelineYear(value[0])}
               aria-disabled={disabled}
               onPointerDown={handleEdgePointerDown("start")}
               onKeyDown={handleEdgeKeyDown("start")}
@@ -207,7 +208,7 @@ export function TimelineRangeBar({
               aria-valuemin={value[0]}
               aria-valuemax={maxYear}
               aria-valuenow={value[1]}
-              aria-valuetext={formatYear(value[1])}
+              aria-valuetext={formatTimelineYear(value[1])}
               aria-disabled={disabled}
               onPointerDown={handleEdgePointerDown("end")}
               onKeyDown={handleEdgeKeyDown("end")}
@@ -220,8 +221,8 @@ export function TimelineRangeBar({
       </div>
 
       <div className="text-muted-foreground flex justify-between text-[0.65rem] tracking-wide uppercase">
-        <span>{formatYear(minYear)}</span>
-        <span>{formatYear(maxYear)}</span>
+        <span>{formatTimelineYear(minYear)}</span>
+        <span>{formatTimelineYear(maxYear)}</span>
       </div>
     </div>
   );

--- a/src/components/game/TimelineRangeBar.tsx
+++ b/src/components/game/TimelineRangeBar.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import React, { useCallback, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { formatYear } from "@/lib/displayFormatting";
+
+type DragTarget = "start" | "end" | "new" | null;
+
+export interface TimelineRangeBarProps {
+  /** Earliest selectable internal year (negative = BC). */
+  minYear: number;
+  /** Latest selectable internal year. */
+  maxYear: number;
+  /** Current draft range in internal year units. Ignored visually until `hasValue`. */
+  value: [number, number];
+  /** Whether `value` reflects a range the player actually drew (vs. the unset default). */
+  hasValue: boolean;
+  /** Fired continuously during drag/keyboard adjustment with the next candidate range. */
+  onChange: (range: [number, number]) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const FINE_STEP = 1;
+const COARSE_STEP = 10;
+
+/**
+ * A single-gesture range picker: press-drag-release directly on the timeline
+ * draws a range anchored at the press point (not a fixed default), with live
+ * width feedback via `onChange` on every pointer move. Once a range exists,
+ * the two edges become independently draggable and keyboard-adjustable
+ * `role="slider"` handles for fine-tuning.
+ *
+ * Deliberately player-driven only: this component never reads or infers the
+ * puzzle answer, so it cannot leak era/year information (puzzle-integrity
+ * red line).
+ */
+export function TimelineRangeBar({
+  minYear,
+  maxYear,
+  value,
+  hasValue,
+  onChange,
+  disabled = false,
+  className,
+}: TimelineRangeBarProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<number | null>(null);
+  const dragTargetRef = useRef<DragTarget>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const span = Math.max(1, maxYear - minYear);
+
+  const yearFromClientX = useCallback(
+    (clientX: number) => {
+      const rect = trackRef.current?.getBoundingClientRect();
+      if (!rect || rect.width === 0) return minYear;
+      const fraction = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
+      return Math.round(minYear + fraction * span);
+    },
+    [minYear, span],
+  );
+
+  const pctFor = useCallback(
+    (year: number) => {
+      const clamped = Math.min(maxYear, Math.max(minYear, year));
+      return ((clamped - minYear) / span) * 100;
+    },
+    [minYear, maxYear, span],
+  );
+
+  const applyPointerYear = useCallback(
+    (clientX: number) => {
+      const year = yearFromClientX(clientX);
+      const target = dragTargetRef.current;
+
+      if (target === "start") {
+        onChange([Math.min(year, value[1]), value[1]]);
+      } else if (target === "end") {
+        onChange([value[0], Math.max(year, value[0])]);
+      } else if (target === "new") {
+        const anchor = anchorRef.current ?? year;
+        onChange([Math.min(anchor, year), Math.max(anchor, year)]);
+      }
+    },
+    [onChange, value, yearFromClientX],
+  );
+
+  const handleTrackPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    trackRef.current?.setPointerCapture?.(e.pointerId);
+    const year = yearFromClientX(e.clientX);
+    anchorRef.current = year;
+    dragTargetRef.current = "new";
+    setIsDragging(true);
+    onChange([year, year]);
+  };
+
+  const handleEdgePointerDown =
+    (edge: "start" | "end") => (e: React.PointerEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      e.stopPropagation();
+      trackRef.current?.setPointerCapture?.(e.pointerId);
+      dragTargetRef.current = edge;
+      setIsDragging(true);
+    };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) return;
+    applyPointerYear(e.clientX);
+  };
+
+  const endDrag = () => {
+    setIsDragging(false);
+    dragTargetRef.current = null;
+    anchorRef.current = null;
+  };
+
+  const handleEdgeKeyDown = (edge: "start" | "end") => (e: React.KeyboardEvent) => {
+    if (disabled) return;
+    const delta = e.shiftKey ? COARSE_STEP : FINE_STEP;
+    let [nextStart, nextEnd] = value;
+
+    switch (e.key) {
+      case "ArrowLeft":
+      case "ArrowDown":
+        if (edge === "start") nextStart = Math.max(minYear, value[0] - delta);
+        else nextEnd = Math.max(value[0], value[1] - delta);
+        break;
+      case "ArrowRight":
+      case "ArrowUp":
+        if (edge === "start") nextStart = Math.min(value[1], value[0] + delta);
+        else nextEnd = Math.min(maxYear, value[1] + delta);
+        break;
+      case "Home":
+        if (edge === "start") nextStart = minYear;
+        else nextEnd = value[0];
+        break;
+      case "End":
+        if (edge === "start") nextStart = value[1];
+        else nextEnd = maxYear;
+        break;
+      default:
+        return;
+    }
+
+    e.preventDefault();
+    onChange([nextStart, nextEnd]);
+  };
+
+  const showZeroTick = minYear < 0 && maxYear > 0;
+
+  return (
+    <div className={cn("space-y-1.5", className)}>
+      <div
+        ref={trackRef}
+        onPointerDown={handleTrackPointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        data-testid="timeline-range-track"
+        className={cn(
+          "bg-muted/60 relative h-11 touch-none rounded-full transition-colors select-none",
+          disabled ? "cursor-not-allowed opacity-50" : "hover:bg-muted/80 cursor-crosshair",
+        )}
+      >
+        {showZeroTick && (
+          <div
+            aria-hidden="true"
+            className="bg-border absolute top-0 h-full w-px"
+            style={{ left: `${pctFor(0)}%` }}
+          />
+        )}
+
+        {hasValue && (
+          <div
+            aria-hidden="true"
+            className="bg-primary/40 absolute inset-y-0 rounded-full"
+            style={{
+              left: `${pctFor(value[0])}%`,
+              width: `${Math.max(0.6, pctFor(value[1]) - pctFor(value[0]))}%`,
+            }}
+          />
+        )}
+
+        {hasValue && (
+          <>
+            <div
+              role="slider"
+              tabIndex={disabled ? -1 : 0}
+              aria-label="Start year handle"
+              aria-valuemin={minYear}
+              aria-valuemax={value[1]}
+              aria-valuenow={value[0]}
+              aria-valuetext={formatYear(value[0])}
+              aria-disabled={disabled}
+              onPointerDown={handleEdgePointerDown("start")}
+              onKeyDown={handleEdgeKeyDown("start")}
+              data-testid="timeline-handle-start"
+              className="border-primary bg-background focus-visible:ring-primary absolute top-1/2 h-6 w-6 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 shadow-md outline-none focus-visible:ring-2"
+              style={{ left: `${pctFor(value[0])}%` }}
+            />
+            <div
+              role="slider"
+              tabIndex={disabled ? -1 : 0}
+              aria-label="End year handle"
+              aria-valuemin={value[0]}
+              aria-valuemax={maxYear}
+              aria-valuenow={value[1]}
+              aria-valuetext={formatYear(value[1])}
+              aria-disabled={disabled}
+              onPointerDown={handleEdgePointerDown("end")}
+              onKeyDown={handleEdgeKeyDown("end")}
+              data-testid="timeline-handle-end"
+              className="border-primary bg-background focus-visible:ring-primary absolute top-1/2 h-6 w-6 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 shadow-md outline-none focus-visible:ring-2"
+              style={{ left: `${pctFor(value[1])}%` }}
+            />
+          </>
+        )}
+      </div>
+
+      <div className="text-muted-foreground flex justify-between text-[0.65rem] tracking-wide uppercase">
+        <span>{formatYear(minYear)}</span>
+        <span>{formatYear(maxYear)}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/__tests__/RangeInput.integration.test.tsx
+++ b/src/components/game/__tests__/RangeInput.integration.test.tsx
@@ -19,6 +19,22 @@ vi.mock("@/components/kit/EraToggle", () => ({
   ),
 }));
 
+// jsdom lays every element out at 0×0 - stub a fixed, non-zero track rect so
+// the timeline bar's pointer-position math is deterministic.
+function mockTrackRect() {
+  vi.spyOn(HTMLDivElement.prototype, "getBoundingClientRect").mockReturnValue({
+    left: 0,
+    right: 1000,
+    width: 1000,
+    top: 0,
+    bottom: 40,
+    height: 40,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  });
+}
+
 describe("RangeInput", () => {
   const renderRangeInput = (overrides: Partial<Parameters<typeof RangeInput>[0]> = {}) =>
     render(
@@ -40,16 +56,23 @@ describe("RangeInput", () => {
   });
 
   describe("Default State", () => {
-    it("defaults to zero range (0 AD - 0 AD)", () => {
+    it("starts with empty exact-year fields, not a fake year", () => {
       renderRangeInput();
 
-      // Should display default years in inputs
+      // No range exists yet - regression guard for the old "0 AD - 0 AD"
+      // default, a year that does not exist historically.
       const startInput = screen.getByLabelText(/from year/i);
       const endInput = screen.getByLabelText(/to year/i);
 
-      // Default is 0 AD for both start and end
-      expect(startInput).toHaveValue("0");
-      expect(endInput).toHaveValue("0");
+      expect(startInput).toHaveValue("");
+      expect(endInput).toHaveValue("");
+      expect(screen.getByText(/not set yet/i)).toBeInTheDocument();
+    });
+
+    it("teaches the one-shot mechanic before the first lock-in", () => {
+      renderRangeInput({ isOneGuessMode: true });
+
+      expect(screen.getByText(/one guess.*drag/i)).toBeInTheDocument();
     });
 
     it("disables submit button until range is modified", () => {
@@ -85,13 +108,53 @@ describe("RangeInput", () => {
       // Now should show error
       expect(screen.getByText(/exceeds limit/i)).toBeInTheDocument();
     });
+
+    it("uses the entered end year as both bounds when end year is entered first", () => {
+      renderRangeInput();
+
+      const startInput = screen.getByLabelText(/from year/i);
+      const endInput = screen.getByLabelText(/to year/i);
+
+      fireEvent.change(endInput, { target: { value: "1950" } });
+      fireEvent.blur(endInput);
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(startInput).toHaveValue("1950");
+      expect(endInput).toHaveValue("1950");
+      expect(screen.queryByText("0 AD", { exact: true })).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /submit range/i })).toBeEnabled();
+    });
+
+    it("does not expand a first BC start edit against the unset sentinel", () => {
+      renderRangeInput();
+
+      const startInput = screen.getByLabelText(/from year/i);
+      const endInput = screen.getByLabelText(/to year/i);
+
+      fireEvent.change(startInput, { target: { value: "500" } });
+      fireEvent.click(screen.getAllByTestId("toggle-bc-AD")[0]);
+      fireEvent.blur(startInput);
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(startInput).toHaveValue("500");
+      expect(endInput).toHaveValue("500");
+      expect(screen.queryByText("0 AD", { exact: true })).not.toBeInTheDocument();
+      expect(screen.queryByText(/exceeds limit/i)).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /submit range/i })).toBeEnabled();
+    });
   });
 
   describe("BC/AD Era Toggles", () => {
     it("renders era toggles for both start and end years", () => {
       renderRangeInput();
 
-      // Initially both should be AD (default is 0 AD for both)
+      // Initially both era choices default to AD, even though the year fields are empty.
       const adToggles = screen.getAllByTestId("era-toggle-AD");
       expect(adToggles).toHaveLength(2);
     });
@@ -231,8 +294,6 @@ describe("RangeInput", () => {
       fireEvent.blur(startInput);
 
       fireEvent.change(endInput, { target: { value: "100" } });
-      // Toggle end to BC to get BC-BC range
-      fireEvent.click(screen.getByTestId("toggle-bc-AD"));
       fireEvent.blur(endInput);
 
       act(() => {
@@ -269,7 +330,7 @@ describe("RangeInput", () => {
 
       const endInput = screen.getByLabelText(/to year/i);
 
-      // Enter a year in the future (e.g., 3000 AD when max is 2025 AD)
+      // Enter a year beyond the configured maximum.
       fireEvent.change(endInput, { target: { value: "3000" } });
       fireEvent.blur(endInput);
 
@@ -388,7 +449,7 @@ describe("RangeInput", () => {
       renderRangeInput();
 
       // Width 50, 0 hints: quadratic curve pays 96 (the old linear UI math
-      // would have claimed 80 — regression guard).
+      // would have claimed 80 - regression guard).
       setRange("1900", "1949");
 
       expect(screen.getByText(/pts if right/i)).toBeInTheDocument();
@@ -502,6 +563,77 @@ describe("RangeInput", () => {
       });
 
       expect(handleCommit).toHaveBeenCalledWith(expect.objectContaining({ hintsUsed: 2 }));
+    });
+  });
+
+  describe("Timeline Bar (primary one-gesture path)", () => {
+    beforeEach(() => {
+      mockTrackRect();
+    });
+
+    it("drawing a range on the bar syncs the exact-year fallback fields and enables submit", () => {
+      const handleCommit = vi.fn();
+      renderRangeInput({ onCommit: handleCommit });
+
+      const track = screen.getByTestId("timeline-range-track");
+      const commitButton = screen.getByRole("button", { name: /submit range/i });
+      expect(commitButton).toBeDisabled();
+
+      // GAME_CONFIG span is MIN_YEAR..MAX_YEAR; drag from the midpoint out
+      // to a later point to draw a real (non-trivial) range.
+      fireEvent.pointerDown(track, { clientX: 500, pointerId: 1 });
+      fireEvent.pointerMove(track, { clientX: 520, pointerId: 1 });
+      fireEvent.pointerUp(track, { clientX: 520, pointerId: 1 });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      // The fallback numeric fields should reflect exactly what was drawn -
+      // both paths share the same underlying range state.
+      const startInput = screen.getByLabelText(/from year/i) as HTMLInputElement;
+      const endInput = screen.getByLabelText(/to year/i) as HTMLInputElement;
+      expect(startInput.value).not.toBe("");
+      expect(endInput.value).not.toBe("");
+      expect(commitButton).toBeEnabled();
+
+      act(() => {
+        fireEvent.click(commitButton);
+      });
+      act(() => {
+        vi.runOnlyPendingTimers();
+      });
+
+      expect(handleCommit).toHaveBeenCalled();
+    });
+
+    it("typing exact years syncs the bar's live value (bidirectional)", () => {
+      renderRangeInput();
+
+      const startInput = screen.getByLabelText(/from year/i);
+      const endInput = screen.getByLabelText(/to year/i);
+
+      fireEvent.change(startInput, { target: { value: "1900" } });
+      fireEvent.blur(startInput);
+      fireEvent.change(endInput, { target: { value: "1950" } });
+      fireEvent.blur(endInput);
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      const startHandle = screen.getByTestId("timeline-handle-start");
+      const endHandle = screen.getByTestId("timeline-handle-end");
+      expect(startHandle).toHaveAttribute("aria-valuetext", "1900 AD");
+      expect(endHandle).toHaveAttribute("aria-valuetext", "1950 AD");
+    });
+
+    it("renders no handles and a neutral placeholder before any range is drawn", () => {
+      renderRangeInput();
+
+      expect(screen.queryByTestId("timeline-handle-start")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("timeline-handle-end")).not.toBeInTheDocument();
+      expect(screen.getByText(/not set yet/i)).toBeInTheDocument();
     });
   });
 });

--- a/src/components/game/__tests__/TimelineRangeBar.test.tsx
+++ b/src/components/game/__tests__/TimelineRangeBar.test.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { TimelineRangeBar } from "../TimelineRangeBar";
+
+// jsdom lays every element out at 0×0 - stub a fixed, non-zero track rect so
+// pointer-position math is deterministic. Track spans a 1000px-wide element
+// mapped left-to-right across the full [minYear, maxYear] span.
+function mockTrackRect() {
+  vi.spyOn(HTMLDivElement.prototype, "getBoundingClientRect").mockReturnValue({
+    left: 0,
+    right: 1000,
+    width: 1000,
+    top: 0,
+    bottom: 40,
+    height: 40,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  });
+}
+
+describe("TimelineRangeBar", () => {
+  const minYear = -1000;
+  const maxYear = 1000;
+  // 2000-year span over a 1000px track = 2 years/px.
+
+  beforeEach(() => {
+    mockTrackRect();
+  });
+
+  it("renders no handles until a range exists", () => {
+    render(
+      <TimelineRangeBar
+        minYear={minYear}
+        maxYear={maxYear}
+        value={[0, 0]}
+        hasValue={false}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("slider")).not.toBeInTheDocument();
+  });
+
+  it("draws a fresh range anchored at the press point on a single drag", () => {
+    const onChange = vi.fn();
+    render(
+      <TimelineRangeBar
+        minYear={minYear}
+        maxYear={maxYear}
+        value={[0, 0]}
+        hasValue={false}
+        onChange={onChange}
+      />,
+    );
+
+    const track = screen.getByTestId("timeline-range-track");
+
+    // Press at x=500 (year 0), drag to x=750 (year 500).
+    fireEvent.pointerDown(track, { clientX: 500, pointerId: 1 });
+    expect(onChange).toHaveBeenLastCalledWith([0, 0]);
+
+    fireEvent.pointerMove(track, { clientX: 750, pointerId: 1 });
+    expect(onChange).toHaveBeenLastCalledWith([0, 500]);
+
+    fireEvent.pointerUp(track, { clientX: 750, pointerId: 1 });
+  });
+
+  it("draws the range symmetrically when the drag moves left of the anchor", () => {
+    const onChange = vi.fn();
+    render(
+      <TimelineRangeBar
+        minYear={minYear}
+        maxYear={maxYear}
+        value={[0, 0]}
+        hasValue={false}
+        onChange={onChange}
+      />,
+    );
+
+    const track = screen.getByTestId("timeline-range-track");
+
+    // Press at x=750 (year 500), drag left to x=500 (year 0).
+    fireEvent.pointerDown(track, { clientX: 750, pointerId: 1 });
+    fireEvent.pointerMove(track, { clientX: 500, pointerId: 1 });
+
+    expect(onChange).toHaveBeenLastCalledWith([0, 500]);
+  });
+
+  it("ignores pointer movement before a press starts a drag", () => {
+    const onChange = vi.fn();
+    render(
+      <TimelineRangeBar
+        minYear={minYear}
+        maxYear={maxYear}
+        value={[0, 0]}
+        hasValue={false}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.pointerMove(screen.getByTestId("timeline-range-track"), { clientX: 750 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not draw a range when disabled", () => {
+    const onChange = vi.fn();
+    render(
+      <TimelineRangeBar
+        minYear={minYear}
+        maxYear={maxYear}
+        value={[0, 0]}
+        hasValue={false}
+        onChange={onChange}
+        disabled
+      />,
+    );
+
+    fireEvent.pointerDown(screen.getByTestId("timeline-range-track"), {
+      clientX: 500,
+      pointerId: 1,
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("renders start/end slider handles with era-aware labels once a range exists", () => {
+    render(
+      <TimelineRangeBar
+        minYear={minYear}
+        maxYear={maxYear}
+        value={[-100, 200]}
+        hasValue
+        onChange={vi.fn()}
+      />,
+    );
+
+    const start = screen.getByTestId("timeline-handle-start");
+    const end = screen.getByTestId("timeline-handle-end");
+
+    expect(start).toHaveAttribute("role", "slider");
+    expect(start).toHaveAttribute("aria-valuetext", "100 BC");
+    expect(end).toHaveAttribute("role", "slider");
+    expect(end).toHaveAttribute("aria-valuetext", "200 AD");
+  });
+
+  it("nudges the start handle by 1 year on ArrowRight and 10 on Shift+ArrowRight", () => {
+    const onChange = vi.fn();
+    render(
+      <TimelineRangeBar
+        minYear={minYear}
+        maxYear={maxYear}
+        value={[0, 500]}
+        hasValue
+        onChange={onChange}
+      />,
+    );
+
+    const start = screen.getByTestId("timeline-handle-start");
+
+    fireEvent.keyDown(start, { key: "ArrowRight" });
+    expect(onChange).toHaveBeenLastCalledWith([1, 500]);
+
+    fireEvent.keyDown(start, { key: "ArrowRight", shiftKey: true });
+    expect(onChange).toHaveBeenLastCalledWith([10, 500]);
+  });
+
+  it("clamps the start handle so it never crosses the end handle", () => {
+    const onChange = vi.fn();
+    render(
+      <TimelineRangeBar
+        minYear={minYear}
+        maxYear={maxYear}
+        value={[498, 500]}
+        hasValue
+        onChange={onChange}
+      />,
+    );
+
+    const start = screen.getByTestId("timeline-handle-start");
+    fireEvent.keyDown(start, { key: "ArrowRight", shiftKey: true });
+
+    expect(onChange).toHaveBeenLastCalledWith([500, 500]);
+  });
+
+  it("does not respond to keyboard input when disabled", () => {
+    const onChange = vi.fn();
+    render(
+      <TimelineRangeBar
+        minYear={minYear}
+        maxYear={maxYear}
+        value={[0, 500]}
+        hasValue
+        onChange={onChange}
+        disabled
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByTestId("timeline-handle-start"), { key: "ArrowRight" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a self-contained design lab with 8 structurally distinct classic range-entry options under `docs/labs/classic-range-entry-lab.html`.
- Implements the selected winner: a drag-to-draw timeline range bar with live width/points feedback and keyboard-adjustable range handles.
- Keeps exact-year text entry plus player-driven BC/AD toggles as fallback, removes the visible fake `0 AD -> 0 AD` default, and moves focus to the results summary after submit.

## Design Decision

Winner: R1, drag-to-draw timeline bar.

Rationale: it is the only option that turns the unset state into a valid range around the player's hunch in one continuous press-drag-release gesture, anchored exactly where the player starts. It reuses the same timeline/range mental model already shown on the completion screen, updates width and points on every drag movement, keeps era selection fully player-driven, and has the lowest accessibility cost because the resulting range edges are ordinary `role="slider"` handles with arrow-key controls.

Lab: `docs/labs/classic-range-entry-lab.html`

## Verification

- `bun run test src/components/game/__tests__/TimelineRangeBar.test.tsx src/components/game/__tests__/RangeInput.integration.test.tsx src/components/__tests__/GameLayout.test.tsx`
- `PORT=3217 TEST_PORT=3217 bunx playwright test e2e/classic-range-entry.spec.ts --project=chromium`
- `bunx impeccable detect src/components/game/RangeInput.tsx src/components/game/TimelineRangeBar.tsx docs/labs/classic-range-entry-lab.html`
- `bun run lint && bun run type-check && bun run test`
- `bun run ci:dagger:lint && bun run ci:dagger:type-check && bun run ci:dagger:coverage`
- `bun run build`
- `bunx convex run puzzles:getTotalPuzzles` -> `count: 330`

## Notes

- Browser plugin path was attempted for rendered QA, but no in-app browser backends were available (`agent.browsers.list()` returned `[]`), so the targeted Playwright workflow was used.
- The first local Playwright attempt reused a stale server on port 3000 and showed `/classic` as 404; rerun used `PORT=3217 TEST_PORT=3217` to force this checkout's Next server.

Agent: codex-gpt-5.5
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5.5
Agent-Task: chrondle-ux-range-entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more interactive timeline range picker with drag, keyboard, and exact-year input support.
  * Improved the game’s default state so empty ranges now show clearer “not set yet” guidance instead of a prefilled range.
  * Added a detailed classic range-entry lab page with comparisons, verdicts, and navigation.

* **Bug Fixes**
  * Improved layout stability during range entry and reduced visible shifting.
  * Focus now moves to the results area after submitting a completed range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->