### PR TITLE
fix: sharpen Chrondle share surface (chrondle-911)

### DIFF
--- a/docs/labs/pitch-share-surface-og-lab.html
+++ b/docs/labs/pitch-share-surface-og-lab.html
@@ -1,0 +1,553 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chrondle 911 — OG image decision lab</title>
+    <style>
+      :root {
+        --paper: #fbfaf7;
+        --sheet: #ffffff;
+        --ink: #171717;
+        --muted: #6f6b63;
+        --line: #d9d4ca;
+        --accent: #ea5a1b;
+        --blue: #1f6feb;
+        --green: #188a5d;
+        --gold: #b7791f;
+        --rose: #b42318;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: #f1eee8;
+        color: var(--ink);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        padding: 32px 20px 72px;
+      }
+      header,
+      .verdict {
+        max-width: 1120px;
+        margin: 0 auto 24px;
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 28px;
+      }
+      p {
+        margin: 0;
+        color: var(--muted);
+        line-height: 1.5;
+      }
+      .locked {
+        margin-top: 14px;
+        border: 1px solid var(--line);
+        background: var(--sheet);
+        border-radius: 8px;
+        padding: 12px 14px;
+        font-size: 14px;
+      }
+      .grid {
+        max-width: 1120px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 20px;
+      }
+      @media (max-width: 920px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .option {
+        background: var(--sheet);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      .meta {
+        padding: 14px 16px;
+        border-bottom: 1px solid var(--line);
+      }
+      .meta h2 {
+        margin: 0;
+        font-size: 17px;
+      }
+      .meta p {
+        margin-top: 6px;
+        font-size: 13px;
+      }
+      .winner .meta {
+        border-color: #95d5b2;
+        background: #f1fbf5;
+      }
+      .badge {
+        display: inline-block;
+        margin-left: 8px;
+        border: 1px solid var(--green);
+        color: var(--green);
+        border-radius: 999px;
+        padding: 1px 8px;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .preview-wrap {
+        padding: 16px;
+        background: #e8e4db;
+      }
+      .preview {
+        width: 100%;
+        aspect-ratio: 1200 / 630;
+        border: 1px solid #bdb6aa;
+        background: var(--paper);
+        position: relative;
+        overflow: hidden;
+        box-shadow: 0 10px 28px rgba(0, 0, 0, 0.08);
+      }
+      .small {
+        width: 240px;
+        aspect-ratio: 1200 / 630;
+        margin-top: 10px;
+        border: 1px solid #bdb6aa;
+        background: var(--paper);
+        position: relative;
+        overflow: hidden;
+      }
+      .wordmark {
+        font-weight: 850;
+        letter-spacing: 0.12em;
+      }
+      .kicker {
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--accent);
+        font-weight: 800;
+      }
+      .domain {
+        position: absolute;
+        bottom: 7.5%;
+        left: 7%;
+        font-size: 16px;
+        color: var(--muted);
+      }
+      .mini-label {
+        font-size: 9px;
+        color: var(--muted);
+        margin-top: 4px;
+      }
+
+      /* Option-specific 1200x630 scaled compositions. */
+      .opt1 .preview,
+      .opt1 .small {
+        padding: 7%;
+      }
+      .opt1 h3 {
+        margin: 24px 0 0;
+        font-size: 46px;
+        line-height: 1.02;
+        max-width: 78%;
+      }
+      .opt1 .steps {
+        display: flex;
+        gap: 12px;
+        margin-top: 32px;
+      }
+      .opt1 .step {
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 12px;
+        flex: 1;
+        background: #fff;
+        font-weight: 700;
+        font-size: 14px;
+      }
+
+      .opt2 .preview,
+      .opt2 .small {
+        padding: 6%;
+        background: #171717;
+        color: white;
+      }
+      .opt2 h3 {
+        margin: 22px 0 0;
+        font-size: 42px;
+        line-height: 1.05;
+      }
+      .opt2 .ticket {
+        margin-top: 28px;
+        border: 1px dashed #777;
+        border-radius: 6px;
+        padding: 14px;
+        color: #ddd;
+      }
+
+      .opt3 .preview,
+      .opt3 .small {
+        padding: 6.5%;
+      }
+      .opt3 .cards {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 12px;
+        margin-top: 28px;
+      }
+      .opt3 .card {
+        min-height: 88px;
+        border: 2px solid var(--ink);
+        border-radius: 6px;
+        padding: 12px;
+        background: #fff;
+        box-shadow: 5px 5px 0 #f2c94c;
+      }
+      .opt3 h3 {
+        margin: 18px 0 0;
+        font-size: 39px;
+      }
+
+      .opt4 .preview,
+      .opt4 .small {
+        padding: 6%;
+        background: #f8fafc;
+      }
+      .opt4 .timeline {
+        height: 10px;
+        background: linear-gradient(90deg, var(--blue), var(--green), var(--gold), var(--rose));
+        margin-top: 44px;
+        border-radius: 999px;
+      }
+      .opt4 h3 {
+        margin: 26px 0 0;
+        font-size: 44px;
+        max-width: 72%;
+      }
+
+      .opt5 .preview,
+      .opt5 .small {
+        padding: 6%;
+        background: #fff;
+      }
+      .opt5 .receipt {
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        padding: 18px;
+        width: 55%;
+        background: #fbfaf7;
+      }
+      .opt5 h3 {
+        margin: 18px 0 0;
+        font-size: 34px;
+      }
+      .opt5 .range {
+        position: absolute;
+        right: 7%;
+        top: 26%;
+        font-size: 74px;
+        font-weight: 900;
+        color: var(--accent);
+      }
+
+      .opt6 .preview,
+      .opt6 .small {
+        padding: 6.5%;
+        background: #f8f5ee;
+      }
+      .opt6 h3 {
+        margin: 18px 0 0;
+        font-size: 45px;
+        line-height: 1.04;
+        max-width: 78%;
+      }
+      .opt6 .tiles {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 12px;
+        margin-top: 28px;
+      }
+      .opt6 .tile {
+        border: 1px solid var(--line);
+        background: white;
+        border-radius: 6px;
+        padding: 12px;
+        min-height: 80px;
+      }
+      .opt6 .tile b {
+        display: block;
+        font-size: 12px;
+        color: var(--accent);
+        margin-bottom: 6px;
+      }
+
+      .small * {
+        transform-origin: top left;
+      }
+      .small .wordmark {
+        font-size: 13px;
+      }
+      .small .kicker {
+        font-size: 5px;
+      }
+      .small h3 {
+        font-size: 18px;
+        margin-top: 8px;
+      }
+      .small .steps,
+      .small .cards,
+      .small .tiles {
+        gap: 4px;
+        margin-top: 9px;
+      }
+      .small .step,
+      .small .card,
+      .small .tile {
+        padding: 4px;
+        font-size: 5px;
+        min-height: 30px;
+        box-shadow: none;
+        border-width: 1px;
+      }
+      .small .ticket,
+      .small .receipt {
+        padding: 5px;
+        font-size: 5px;
+      }
+      .small .timeline {
+        margin-top: 16px;
+        height: 4px;
+      }
+      .small .range {
+        font-size: 24px;
+      }
+      .small .domain {
+        font-size: 6px;
+      }
+      .verdict {
+        margin-top: 28px;
+        border: 2px solid var(--green);
+        border-radius: 8px;
+        background: #f1fbf5;
+        padding: 16px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Chrondle 911 — OG image decision lab</h1>
+      <p>
+        Six structurally distinct 1200x630 share-preview directions. Each option also includes a
+        small-preview render because issue #191 complained the current image was too big, too dark,
+        and muddy at social-card sizes.
+      </p>
+      <div class="locked">
+        <strong>Locked pitch:</strong> A daily history puzzle: read the clues, guess the year. One
+        real event per day, free at chrondle.app.
+      </div>
+    </header>
+
+    <main class="grid">
+      <section class="option opt1">
+        <div class="meta">
+          <h2>1. Editorial How Strip</h2>
+          <p>
+            Plain product explanation: wordmark, direct headline, three mechanic tiles. Strongest at
+            small sizes because the hierarchy survives compression.
+          </p>
+        </div>
+        <div class="preview-wrap">
+          <div class="preview">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="kicker">Daily history puzzle</div>
+            <h3>Read clues. Guess the year.</h3>
+            <div class="steps">
+              <div class="step">1 Read a real event</div>
+              <div class="step">2 Enter your range</div>
+              <div class="step">3 Share your score</div>
+            </div>
+            <div class="domain">Free at chrondle.app</div>
+          </div>
+          <div class="small">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="kicker">Daily history puzzle</div>
+            <h3>Read clues. Guess the year.</h3>
+            <div class="steps">
+              <div class="step">1 Read a real event</div>
+              <div class="step">2 Enter your range</div>
+              <div class="step">3 Share your score</div>
+            </div>
+            <div class="domain">Free at chrondle.app</div>
+          </div>
+          <div class="mini-label">Small preview</div>
+        </div>
+      </section>
+
+      <section class="option opt2">
+        <div class="meta">
+          <h2>2. Night Archive</h2>
+          <p>
+            Dark, cinematic archive-ticket framing. Memorable, but it repeats the complaint's
+            darkness and loses small-text legibility.
+          </p>
+        </div>
+        <div class="preview-wrap">
+          <div class="preview">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="kicker">Free daily game</div>
+            <h3>A real event. Six clues. One year.</h3>
+            <div class="ticket">TODAY'S PUZZLE · Guess the year from history</div>
+            <div class="domain">chrondle.app</div>
+          </div>
+          <div class="small">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="kicker">Free daily game</div>
+            <h3>A real event. Six clues. One year.</h3>
+            <div class="ticket">TODAY'S PUZZLE · Guess the year from history</div>
+            <div class="domain">chrondle.app</div>
+          </div>
+          <div class="mini-label">Small preview</div>
+        </div>
+      </section>
+
+      <section class="option opt3">
+        <div class="meta">
+          <h2>3. Stacked Clue Cards</h2>
+          <p>
+            Three clue-card blocks dramatize the game object. It is lively, but the cards compete
+            with the brand and can look noisy in message previews.
+          </p>
+        </div>
+        <div class="preview-wrap">
+          <div class="preview">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="kicker">Daily history puzzle</div>
+            <h3>Can you place the event?</h3>
+            <div class="cards">
+              <div class="card">Clue 1<br />Real event</div>
+              <div class="card">Clue 2<br />Narrow range</div>
+              <div class="card">Clue 3<br />Score</div>
+            </div>
+            <div class="domain">chrondle.app</div>
+          </div>
+          <div class="small">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="kicker">Daily history puzzle</div>
+            <h3>Can you place the event?</h3>
+            <div class="cards">
+              <div class="card">Clue 1<br />Real event</div>
+              <div class="card">Clue 2<br />Narrow range</div>
+              <div class="card">Clue 3<br />Score</div>
+            </div>
+            <div class="domain">chrondle.app</div>
+          </div>
+          <div class="mini-label">Small preview</div>
+        </div>
+      </section>
+
+      <section class="option opt4">
+        <div class="meta">
+          <h2>4. Timeline Sweep</h2>
+          <p>
+            One long timeline makes the year-guessing premise obvious. It is clean, but it hints at
+            eras as a visual map and risks feeling like a history app, not a daily game.
+          </p>
+        </div>
+        <div class="preview-wrap">
+          <div class="preview">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="timeline"></div>
+            <h3>Where on the timeline did it happen?</h3>
+            <div class="domain">Free at chrondle.app</div>
+          </div>
+          <div class="small">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="timeline"></div>
+            <h3>Where on the timeline did it happen?</h3>
+            <div class="domain">Free at chrondle.app</div>
+          </div>
+          <div class="mini-label">Small preview</div>
+        </div>
+      </section>
+
+      <section class="option opt5">
+        <div class="meta">
+          <h2>5. Score Receipt</h2>
+          <p>
+            Leans into post-game sharing with a result-receipt object. Useful for score posts, but
+            less clear for a first-time preview because it shows outcome grammar before the premise.
+          </p>
+        </div>
+        <div class="preview-wrap">
+          <div class="preview">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="receipt">
+              <div class="kicker">Today</div>
+              <h3>Read clues. Guess the year.</h3>
+              <p>One real event per day.</p>
+            </div>
+            <div class="range">100</div>
+            <div class="domain">chrondle.app</div>
+          </div>
+          <div class="small">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="receipt">
+              <div class="kicker">Today</div>
+              <h3>Read clues. Guess the year.</h3>
+              <p>One real event per day.</p>
+            </div>
+            <div class="range">100</div>
+            <div class="domain">chrondle.app</div>
+          </div>
+          <div class="mini-label">Small preview</div>
+        </div>
+      </section>
+
+      <section class="option opt6 winner">
+        <div class="meta">
+          <h2>6. Clean Clue Tiles <span class="badge">Winner</span></h2>
+          <p>
+            Combines option 1's readable hierarchy with option 3's game-object hint. The wordmark
+            and headline stay dominant; the tiles explain the loop without leaking any era/year
+            data.
+          </p>
+        </div>
+        <div class="preview-wrap">
+          <div class="preview">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="kicker">Daily history puzzle</div>
+            <h3>Read the clues. Guess the year.</h3>
+            <div class="tiles">
+              <div class="tile"><b>1</b>One real event</div>
+              <div class="tile"><b>2</b>Six clues</div>
+              <div class="tile"><b>3</b>Score your range</div>
+            </div>
+            <div class="domain">Free at chrondle.app</div>
+          </div>
+          <div class="small">
+            <div class="wordmark">CHRONDLE</div>
+            <div class="kicker">Daily history puzzle</div>
+            <h3>Read the clues. Guess the year.</h3>
+            <div class="tiles">
+              <div class="tile"><b>1</b>One real event</div>
+              <div class="tile"><b>2</b>Six clues</div>
+              <div class="tile"><b>3</b>Score your range</div>
+            </div>
+            <div class="domain">Free at chrondle.app</div>
+          </div>
+          <div class="mini-label">Small preview</div>
+        </div>
+      </section>
+    </main>
+
+    <section class="verdict">
+      <h2>Decision</h2>
+      <p>
+        <strong>Implement option 6, Clean Clue Tiles.</strong> It is the clearest small-preview
+        read: brand, "read clues / guess year," one real event per day, and free URL are visible
+        without relying on tiny body copy or dark contrast. It also avoids the puzzle-integrity
+        trap: no sample event, no era, no calendar year, no proximity behavior.
+      </p>
+    </section>
+  </body>
+</html>

--- a/e2e/habit-loop.spec.ts
+++ b/e2e/habit-loop.spec.ts
@@ -99,7 +99,7 @@ test.describe("Entry @habit-loop", () => {
     await page.goto("/");
 
     // Can state what the game is: pitch + how-to strip in the first viewport
-    await expect(page.getByText(/guess the year of real historical events/i)).toBeVisible();
+    await expect(page.getByText(/read the clues, guess the year/i)).toBeVisible();
     const howTo = page.getByRole("list", { name: /how to play/i });
     await expect(howTo).toBeVisible();
     await expect(howTo).toContainText(/keep your streak/i);

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,12 @@
-{"name":"Chrondle","short_name":"Chrondle","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ea5a1b","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "Chrondle",
+  "short_name": "Chrondle",
+  "description": "A daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app.",
+  "icons": [
+    { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
+  ],
+  "theme_color": "#ea5a1b",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/src/app/(app)/opengraph-image.tsx
+++ b/src/app/(app)/opengraph-image.tsx
@@ -1,23 +1,16 @@
 import { ImageResponse } from "next/og";
+import { siteConfig } from "@/lib/site";
 
 // NOTE: This file renders a static OG image via Satori, which cannot resolve
 // CSS custom properties. The literal color values below are approved asset
 // data (mirroring the design tokens in globals.css), not component styling.
 export const runtime = "edge";
 
-export const alt = "Chrondle - The Daily History Game";
+export const alt = "Chrondle daily history puzzle preview";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
 export default async function Image() {
-  const outfitFont = await fetch(
-    new URL("https://fonts.gstatic.com/s/outfit/v11/QGYyz_MVcBeNP4NjuGObqx1XmO1I4TC1O4a0Ew.woff"),
-  ).then((res) => res.arrayBuffer());
-
-  const outfitMedium = await fetch(
-    new URL("https://fonts.gstatic.com/s/outfit/v11/QGYyz_MVcBeNP4NjuGObqx1XmO1I4bK0O4a0Ew.woff"),
-  ).then((res) => res.arrayBuffer());
-
   return new ImageResponse(
     <div
       style={{
@@ -25,116 +18,41 @@ export default async function Image() {
         height: "100%",
         display: "flex",
         flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: "#ffffff",
-        fontFamily: "Outfit",
+        alignItems: "stretch",
+        justifyContent: "space-between",
+        backgroundColor: "#fbfaf7",
+        fontFamily: "sans-serif",
         position: "relative",
         overflow: "hidden",
+        padding: "72px 80px 58px",
       }}
     >
-      {/* Subtle warm gradient overlay */}
       <div
         style={{
           position: "absolute",
           top: 0,
           left: 0,
           right: 0,
-          bottom: 0,
-          background:
-            "radial-gradient(ellipse 80% 60% at 50% 40%, rgba(234, 90, 27, 0.04) 0%, transparent 70%)",
-          display: "flex",
-        }}
-      />
-
-      {/* Top accent line */}
-      <div
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          right: 0,
-          height: "4px",
+          height: "10px",
           backgroundColor: "#ea5a1b",
           display: "flex",
         }}
       />
 
-      {/* Corner marks - archival/editorial touch */}
-      <div
-        style={{
-          position: "absolute",
-          top: "40px",
-          left: "48px",
-          width: "24px",
-          height: "24px",
-          borderLeft: "2px solid #d3d6da",
-          borderTop: "2px solid #d3d6da",
-          display: "flex",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          top: "40px",
-          right: "48px",
-          width: "24px",
-          height: "24px",
-          borderRight: "2px solid #d3d6da",
-          borderTop: "2px solid #d3d6da",
-          display: "flex",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: "40px",
-          left: "48px",
-          width: "24px",
-          height: "24px",
-          borderLeft: "2px solid #d3d6da",
-          borderBottom: "2px solid #d3d6da",
-          display: "flex",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          bottom: "40px",
-          right: "48px",
-          width: "24px",
-          height: "24px",
-          borderRight: "2px solid #d3d6da",
-          borderBottom: "2px solid #d3d6da",
-          display: "flex",
-        }}
-      />
-
-      {/* Main content */}
       <div
         style={{
           display: "flex",
-          flexDirection: "column",
+          flexDirection: "row",
           alignItems: "center",
-          justifyContent: "center",
-          gap: "0px",
+          justifyContent: "space-between",
         }}
       >
-        {/* Logo icon - calendar with check */}
-        <svg width="64" height="64" viewBox="0 0 256 256" style={{ marginBottom: "28px" }}>
-          <path
-            d="M208,32H184V24a8,8,0,0,0-16,0v8H88V24a8,8,0,0,0-16,0v8H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32ZM72,48v8a8,8,0,0,0,16,0V48h80v8a8,8,0,0,0,16,0V48h24V80H48V48ZM208,208H48V96H208V208Zm-38.34-85.66a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L116,164.69l42.34-42.35A8,8,0,0,1,169.66,122.34Z"
-            fill="#ea5a1b"
-          />
-        </svg>
-
-        {/* Brand name */}
         <div
           style={{
-            fontSize: "72px",
+            fontSize: "34px",
             fontWeight: 600,
             color: "#1a1a1b",
-            letterSpacing: "0.12em",
+            letterSpacing: "0.14em",
             lineHeight: 1,
             display: "flex",
           }}
@@ -142,78 +60,143 @@ export default async function Image() {
           CHRONDLE
         </div>
 
-        {/* Divider */}
         <div
           style={{
-            width: "48px",
-            height: "2px",
-            backgroundColor: "#ea5a1b",
-            marginTop: "24px",
-            marginBottom: "24px",
-            display: "flex",
-          }}
-        />
-
-        {/* Tagline */}
-        <div
-          style={{
-            fontSize: "24px",
-            fontWeight: 500,
-            color: "#787c7e",
-            letterSpacing: "0.05em",
+            border: "2px solid #1a1a1b",
+            borderRadius: "999px",
+            padding: "9px 16px",
+            fontSize: "18px",
+            fontWeight: 600,
+            color: "#1a1a1b",
             display: "flex",
           }}
         >
-          The Daily History Game
-        </div>
-
-        {/* Subtitle */}
-        <div
-          style={{
-            fontSize: "15px",
-            fontWeight: 400,
-            color: "#9ca3af",
-            letterSpacing: "0.16em",
-            marginTop: "16px",
-            textTransform: "uppercase" as const,
-            display: "flex",
-          }}
-        >
-          Guess the year from six historical clues
+          FREE DAILY GAME
         </div>
       </div>
 
-      {/* Bottom domain */}
       <div
         style={{
-          position: "absolute",
-          bottom: "48px",
-          fontSize: "14px",
-          fontWeight: 400,
-          color: "#d3d6da",
-          letterSpacing: "0.08em",
           display: "flex",
+          flexDirection: "column",
+          gap: "22px",
+          maxWidth: "890px",
         }}
       >
-        chrondle.app
+        <div
+          style={{
+            fontSize: "23px",
+            fontWeight: 600,
+            color: "#ea5a1b",
+            letterSpacing: "0.13em",
+            textTransform: "uppercase",
+            display: "flex",
+          }}
+        >
+          Daily history puzzle
+        </div>
+
+        <div
+          style={{
+            fontSize: "76px",
+            fontWeight: 600,
+            color: "#1a1a1b",
+            letterSpacing: "0",
+            lineHeight: 0.96,
+            display: "flex",
+          }}
+        >
+          Read the clues. Guess the year.
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          gap: "16px",
+          width: "100%",
+        }}
+      >
+        <div
+          style={{
+            flex: 1,
+            minHeight: "112px",
+            border: "2px solid #d9d4ca",
+            borderRadius: "8px",
+            backgroundColor: "#ffffff",
+            padding: "22px 24px",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ color: "#ea5a1b", fontSize: "20px", fontWeight: 600, display: "flex" }}>
+            1
+          </div>
+          <div style={{ color: "#1a1a1b", fontSize: "26px", fontWeight: 600, display: "flex" }}>
+            One real event
+          </div>
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            minHeight: "112px",
+            border: "2px solid #d9d4ca",
+            borderRadius: "8px",
+            backgroundColor: "#ffffff",
+            padding: "22px 24px",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ color: "#1f6feb", fontSize: "20px", fontWeight: 600, display: "flex" }}>
+            2
+          </div>
+          <div style={{ color: "#1a1a1b", fontSize: "26px", fontWeight: 600, display: "flex" }}>
+            Six clues
+          </div>
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            minHeight: "112px",
+            border: "2px solid #d9d4ca",
+            borderRadius: "8px",
+            backgroundColor: "#ffffff",
+            padding: "22px 24px",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ color: "#188a5d", fontSize: "20px", fontWeight: 600, display: "flex" }}>
+            3
+          </div>
+          <div style={{ color: "#1a1a1b", fontSize: "26px", fontWeight: 600, display: "flex" }}>
+            Score your range
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          color: "#6f6b63",
+          fontSize: "24px",
+          fontWeight: 500,
+        }}
+      >
+        <div style={{ display: "flex" }}>One real event per day</div>
+        <div style={{ display: "flex" }}>{siteConfig.url.replace("https://", "")}</div>
       </div>
     </div>,
-    {
-      ...size,
-      fonts: [
-        {
-          name: "Outfit",
-          data: outfitFont,
-          style: "normal",
-          weight: 600,
-        },
-        {
-          name: "Outfit",
-          data: outfitMedium,
-          style: "normal",
-          weight: 500,
-        },
-      ],
-    },
+    size,
   );
 }

--- a/src/components/GamesGallery.tsx
+++ b/src/components/GamesGallery.tsx
@@ -7,6 +7,7 @@ import { useTodaysPuzzle } from "@/hooks/useTodaysPuzzle";
 import { useTodaysOrderPuzzle } from "@/hooks/useTodaysOrderPuzzle";
 import { setModePreferenceCookie, type ModeKey } from "@/lib/modePreference";
 import { MODES } from "@/lib/modes";
+import { siteConfig } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
 // --- Gallery copy (identity — label/route/icon/theme — lives in src/lib/modes) ---
@@ -83,11 +84,9 @@ export function GamesGallery() {
         <header className="flex flex-col gap-2 text-center">
           <h1 className="font-display text-5xl md:text-6xl">Chrondle</h1>
           <p className="text-muted-foreground font-body text-sm text-pretty md:text-base">
-            Daily history puzzles
+            Daily history puzzle
           </p>
-          <p className="font-body text-sm text-pretty md:text-base">
-            Guess the year of real historical events. New puzzles every day.
-          </p>
+          <p className="font-body text-sm text-pretty md:text-base">{siteConfig.description}</p>
         </header>
 
         {/* How it works — compact 3-step strip (structural copy; the

--- a/src/components/__tests__/GamesGallery.test.tsx
+++ b/src/components/__tests__/GamesGallery.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useTodaysPuzzle } from "@/hooks/useTodaysPuzzle";
 import { useTodaysOrderPuzzle } from "@/hooks/useTodaysOrderPuzzle";
+import { siteConfig } from "@/lib/site";
 import { GamesGallery } from "../GamesGallery";
 
 // --- Mocks ---
@@ -93,7 +94,7 @@ describe("GamesGallery", () => {
       render(<GamesGallery />);
 
       expect(screen.getByRole("heading", { level: 1, name: "Chrondle" })).toBeInTheDocument();
-      expect(screen.getByText("Daily history puzzles")).toBeInTheDocument();
+      expect(screen.getByText("Daily history puzzle")).toBeInTheDocument();
     });
 
     it("renders all mode cards with copy, CTAs, and puzzle metadata", () => {
@@ -121,7 +122,7 @@ describe("GamesGallery", () => {
       render(<GamesGallery />);
 
       // The pitch: what Chrondle is
-      expect(screen.getByText(/guess the year of real historical events/i)).toBeInTheDocument();
+      expect(screen.getByText(siteConfig.description)).toBeInTheDocument();
 
       // The how: a compact 3-step strip
       const strip = screen.getByRole("list", { name: /how to play/i });

--- a/src/lib/__tests__/site.test.ts
+++ b/src/lib/__tests__/site.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { siteConfig, siteMetadata } from "@/lib/site";
+
+const LOCKED_PITCH =
+  "A daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app.";
+
+describe("site identity copy", () => {
+  it("uses the locked one-liner as the site description", () => {
+    expect(siteConfig.description).toBe(LOCKED_PITCH);
+    expect(siteMetadata.description).toBe(LOCKED_PITCH);
+  });
+
+  it("carries the locked one-liner through OG and twitter descriptions", () => {
+    expect(siteMetadata.openGraph).toMatchObject({
+      description: LOCKED_PITCH,
+    });
+    expect(siteMetadata.twitter).toMatchObject({
+      description: LOCKED_PITCH,
+    });
+  });
+
+  it("carries the locked one-liner through the web app manifest", () => {
+    const manifest = JSON.parse(
+      readFileSync(join(process.cwd(), "public/site.webmanifest"), "utf8"),
+    ) as { description?: string };
+
+    expect(manifest.description).toBe(LOCKED_PITCH);
+  });
+});

--- a/src/lib/sharing/__tests__/classic.test.ts
+++ b/src/lib/sharing/__tests__/classic.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { generateClassicShareText } from "../classic";
+import { CHRONDLE_URL, SHARE_PITCH } from "../format";
 import { RangeGuess } from "@/types/range";
 
 // Mock logger to prevent console noise
@@ -135,9 +136,18 @@ describe("generateClassicShareText", () => {
 ✅ Contained
 🎯 100/100
 
+A daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app.
 https://chrondle.app`;
 
       expect(result).toBe(expected);
+    });
+
+    it("includes the pitch and URL as plain text for social previews", () => {
+      const result = generateClassicShareText([createRange(1950, 1950)], 100, true, 347);
+
+      expect(result).toContain(SHARE_PITCH);
+      expect(result).toContain(CHRONDLE_URL);
+      expect(result.endsWith(`${SHARE_PITCH}\n${CHRONDLE_URL}`)).toBe(true);
     });
 
     it("generates correct text for a multi-guess win", () => {
@@ -154,6 +164,7 @@ https://chrondle.app`;
 ✅ Contained
 😎 70/100
 
+A daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app.
 https://chrondle.app`;
 
       expect(result).toBe(expected);
@@ -172,6 +183,7 @@ https://chrondle.app`;
 ❌ 7y early
 🫠 0/100
 
+A daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app.
 https://chrondle.app`;
 
       expect(result).toBe(expected);
@@ -190,6 +202,7 @@ https://chrondle.app`;
 ❌ 2y late
 🫠 0/100
 
+A daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app.
 https://chrondle.app`;
 
       expect(result).toBe(expected);

--- a/src/lib/sharing/__tests__/duel.test.ts
+++ b/src/lib/sharing/__tests__/duel.test.ts
@@ -24,7 +24,7 @@ describe("generateDuelShareText", () => {
       });
 
       expect(text).toBe(
-        "Chrondle Duel\n\n⚔️ 12 in a row · Historian\nFelled by a gap of 6 years\n\nhttps://chrondle.app/duel",
+        "Chrondle Duel\n\n⚔️ 12 in a row · Historian\nFelled by a gap of 6 years\n\nA daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app.\nhttps://chrondle.app/duel",
       );
     });
 

--- a/src/lib/sharing/__tests__/leakage.test.ts
+++ b/src/lib/sharing/__tests__/leakage.test.ts
@@ -19,6 +19,7 @@ import { describe, it, expect, vi } from "vitest";
 import { generateClassicShareText } from "../classic";
 import { generateOrderShareText } from "../order";
 import { generateDuelShareText } from "../duel";
+import { SHARE_PITCH } from "../format";
 import type { RangeGuess } from "@/types/range";
 import type { OrderAttempt } from "@/types/orderGameState";
 
@@ -45,7 +46,8 @@ function assertNoCalendarYearShapedNumber(text: string) {
   // this check — only the body (the mechanic-expressing content) matters.
   const [, ...rest] = text.split("\n\n");
   const body = rest.slice(0, -1).join("\n\n");
-  expect(body).not.toMatch(/\b(1[5-9]|20)\d{2}\b/);
+  const bodyWithoutPitch = body.replace(SHARE_PITCH, "");
+  expect(bodyWithoutPitch).not.toMatch(/\b(1[5-9]|20)\d{2}\b/);
 }
 
 const range = (start: number, end: number, hintsUsed = 0): RangeGuess => ({

--- a/src/lib/sharing/__tests__/order.test.ts
+++ b/src/lib/sharing/__tests__/order.test.ts
@@ -151,6 +151,7 @@ describe("generateOrderShareText", () => {
 
 🟩🟩🟩🟩🟩🟩
 
+A daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app.
 https://chrondle.app`;
 
       expect(result).toBe(expected);
@@ -174,6 +175,7 @@ https://chrondle.app`;
 ⬜🟩🟩🟩⬜🟩
 🟩🟩🟩🟩🟩🟩
 
+A daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app.
 https://chrondle.app`;
 
       expect(result).toBe(expected);

--- a/src/lib/sharing/classic.ts
+++ b/src/lib/sharing/classic.ts
@@ -90,6 +90,6 @@ export function generateClassicShareText(
     return buildShareText(header, [funnelLine, outcomeLine, scoreLine], CHRONDLE_URL);
   } catch (error) {
     logger.error("Failed to generate Classic share text:", error);
-    return `Chrondle: Game complete\n${CHRONDLE_URL}`;
+    return buildShareText("Chrondle: Game complete", [], CHRONDLE_URL);
   }
 }

--- a/src/lib/sharing/format.ts
+++ b/src/lib/sharing/format.ts
@@ -1,3 +1,5 @@
+import { siteConfig } from "@/lib/site";
+
 /**
  * Shared share-text format family.
  *
@@ -9,7 +11,8 @@
  * unifies around.
  */
 
-export const CHRONDLE_URL = "https://chrondle.app";
+export const CHRONDLE_URL = siteConfig.url;
+export const SHARE_PITCH = siteConfig.description;
 
 /**
  * Builds the shared header: "Chrondle", optionally suffixed with a mode
@@ -34,5 +37,9 @@ export function buildShareText(
   bodyLines: string[],
   url: string = CHRONDLE_URL,
 ): string {
-  return [header, "", ...bodyLines, "", url].join("\n");
+  if (bodyLines.length === 0) {
+    return [header, "", SHARE_PITCH, url].join("\n");
+  }
+
+  return [header, "", ...bodyLines, "", SHARE_PITCH, url].join("\n");
 }

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,13 +1,16 @@
 import type { Metadata, Viewport } from "next";
 
+export const SITE_PITCH =
+  "A daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app.";
+
 /**
  * Single source of truth for site-wide identity and metadata.
  * Layouts import from here instead of redefining metadata inline.
  */
 export const siteConfig = {
   name: "Chrondle",
-  title: "Chrondle - The Daily History Game",
-  description: "Guess the year of the historical event in this daily puzzle game.",
+  title: "Chrondle - Daily History Puzzle",
+  description: SITE_PITCH,
   url: "https://chrondle.app",
 } as const;
 
@@ -39,6 +42,8 @@ export const siteMetadata: Metadata = {
     title: siteConfig.name,
   },
   openGraph: {
+    title: siteConfig.title,
+    description: siteConfig.description,
     url: siteConfig.url,
     siteName: siteConfig.name,
     type: "website",
@@ -46,5 +51,7 @@ export const siteMetadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
+    title: siteConfig.title,
+    description: siteConfig.description,
   },
 };


### PR DESCRIPTION
Adopts the codex lane's finished work for Powder card chrondle-911 (pitch + share-surface epic). The lane completed implementation and passed the fast local gate (lint, type-check, 2036 tests) but blocked on running the Dagger CI-equivalent gate locally — this PR lets real CI run it.

- Locked pitch across metadata/manifest/gallery: "A daily history puzzle: read the clues, guess the year. One real event per day, free at chrondle.app."
- Share text footer includes pitch + URL; spoiler-safety tests still enforce no calendar-year leakage.
- OG image replaced with design-lab winner "Clean Clue Tiles" (lab: docs/labs/pitch-share-surface-og-lab.html).

Card: chrondle-911

🤖 Generated with [Claude Code](https://claude.com/claude-code)