### PR TITLE
chore: DO App Platform build path (webpack)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "concurrently \"bunx convex dev\" \"next dev --turbopack\"",
     "dev:next": "next dev --turbopack",
     "build": "next build",
+    "build:do": "next build --webpack",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## Summary

Prepare Chrondle for a DigitalOcean App Platform parallel-run by adding a dedicated `build:do` package script that runs `next build --webpack`. This leaves the existing Vercel-oriented `build` script untouched.

## Migration context

Next.js 16 defaults `next build` to Turbopack. On DigitalOcean App Platform buildpacks, Turbopack can panic with `Dependency tracking is disabled so invalidation is not allowed`; the DO build path should use `next build --webpack` instead.

## Known follow-ups

- `.nvmrc` pins Node 20 while Vercel currently runs Node 22. This PR intentionally leaves the Node pin unchanged.
- `src/app/(app)/opengraph-image.tsx` declares `runtime = "edge"`, which has no direct DigitalOcean App Platform equivalent. This PR intentionally leaves it unchanged for the parallel-run; the route may fall back or 500 on DO.

## Validation

- Confirmed `package.json` parses, `scripts.build` remains `next build`, and `scripts["build:do"]` is `next build --webpack`.
- Confirmed the final diff contains only the single `package.json` script addition.

🤖 Generated with Codex (do-migration campaign)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new build command that uses the webpack-based build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->