### PR TITLE
fix(ops): add Chrondle hosting parity doctor

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -288,12 +288,18 @@ console.log("✅ Environment variables validated successfully");
 
 ### Post-Deployment
 
+- [ ] Hosting parity doctor passes (`bun run doctor:hosting`)
 - [ ] Daily puzzle loads correctly
 - [ ] Authentication working
 - [ ] User progress saves
 - [ ] No console errors in production
 - [ ] Performance metrics acceptable
 - [ ] Monitoring configured
+
+`bun run doctor:hosting` is the provider-independent production probe. It fails
+if the Clerk custom-domain CNAME disappears, Clerk's client edge or sign-in
+route stops loading, the production Convex corpus is unavailable, application
+health degrades, or signed-out Stripe requests reach provider actions.
 
 ## Additional Resources
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "events": "tsx scripts/manage-events.ts",
     "events:audit": "tsx scripts/audit-events.ts",
     "deploy:verify": "node scripts/verify-deployment.mjs",
+    "doctor:hosting": "node scripts/verify-hosting-parity.mjs",
     "deploy": "convex deploy && bun run deploy:verify",
     "validate-puzzles": "node scripts/check-convex-state.mjs",
     "verify:convex": "node scripts/verify-convex-files.mjs",

--- a/scripts/verify-hosting-parity.mjs
+++ b/scripts/verify-hosting-parity.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+import { resolveCname as resolveCnameCallback } from "node:dns";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_APP_ORIGIN = "https://chrondle.app";
+const DEFAULT_CLERK_HOST = "clerk.chrondle.app";
+const EXPECTED_CLERK_CNAME = "frontend-api.clerk.services";
+const DEFAULT_CONVEX_URL = "https://fleet-goldfish-183.convex.cloud";
+
+const systemResolveCname = promisify(resolveCnameCallback);
+
+function normalizedHost(value) {
+  return value.toLowerCase().replace(/\.$/, "");
+}
+
+async function capture(name, check) {
+  try {
+    return { name, ...(await check()) };
+  } catch (error) {
+    return { name, ok: false, detail: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function fetchStatus(fetchImpl, url, init) {
+  const response = await fetchImpl(url, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(15_000),
+    ...init,
+  });
+  return response;
+}
+
+async function defaultQueryConvexCorpus() {
+  const [{ ConvexHttpClient }, { api }] = await Promise.all([
+    import("convex/browser"),
+    import("../convex/_generated/api.js"),
+  ]);
+  const client = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL || DEFAULT_CONVEX_URL);
+  const [totalResult, archive] = await Promise.all([
+    client.query(api.puzzles.getTotalPuzzles, {}),
+    client.query(api.puzzles.getArchivePuzzles, { page: 1, pageSize: 1 }),
+  ]);
+  return {
+    totalPuzzles: totalResult.count,
+    latestPuzzleDate: archive.puzzles[0]?.date ?? null,
+  };
+}
+
+export async function verifyHostingParity({
+  appOrigin = DEFAULT_APP_ORIGIN,
+  clerkHost = DEFAULT_CLERK_HOST,
+  fetchImpl = fetch,
+  resolveCname = systemResolveCname,
+  queryConvexCorpus = defaultQueryConvexCorpus,
+} = {}) {
+  const checks = [];
+
+  checks.push(
+    await capture("clerk-cname", async () => {
+      const records = (await resolveCname(clerkHost)).map(normalizedHost);
+      const ok = records.includes(EXPECTED_CLERK_CNAME);
+      return {
+        ok,
+        detail: ok
+          ? `resolved to ${EXPECTED_CLERK_CNAME}`
+          : `expected ${EXPECTED_CLERK_CNAME}; got ${records.length ? records.join(", ") : "no CNAME"}`,
+      };
+    }),
+  );
+
+  checks.push(
+    await capture("clerk-client", async () => {
+      const response = await fetchStatus(fetchImpl, `https://${clerkHost}/v1/client`);
+      return { ok: response.status === 200, detail: `HTTP ${response.status}` };
+    }),
+  );
+
+  checks.push(
+    await capture("convex-corpus", async () => {
+      const { totalPuzzles, latestPuzzleDate } = await queryConvexCorpus();
+      const ok = Number.isInteger(totalPuzzles) && totalPuzzles > 0 && Boolean(latestPuzzleDate);
+      return {
+        ok,
+        detail: `total-puzzles=${totalPuzzles}; latest-date=${latestPuzzleDate ?? "missing"}`,
+      };
+    }),
+  );
+
+  checks.push(
+    await capture("app-health", async () => {
+      const response = await fetchStatus(fetchImpl, `${appOrigin}/api/health`);
+      const body = await response.json();
+      const ok =
+        response.status === 200 &&
+        body.status === "ok" &&
+        body.checks?.convex === "ok" &&
+        body.checks?.canary === "configured";
+      return {
+        ok,
+        detail: `HTTP ${response.status}; convex=${body.checks?.convex ?? "missing"}; canary=${body.checks?.canary ?? "missing"}`,
+      };
+    }),
+  );
+
+  checks.push(
+    await capture("sign-in-route", async () => {
+      const response = await fetchStatus(fetchImpl, `${appOrigin}/sign-in`);
+      const body = await response.text();
+      const referencesClerkDomain = body.includes(clerkHost);
+      return {
+        ok: response.status === 200 && referencesClerkDomain,
+        detail: `HTTP ${response.status}; custom-domain-reference=${referencesClerkDomain}`,
+      };
+    }),
+  );
+
+  for (const [name, path] of [
+    ["stripe-checkout-auth-boundary", "/api/stripe/checkout"],
+    ["stripe-portal-auth-boundary", "/api/stripe/portal"],
+  ]) {
+    checks.push(
+      await capture(name, async () => {
+        const response = await fetchStatus(fetchImpl, `${appOrigin}${path}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{}",
+        });
+        return {
+          ok: response.status === 401,
+          detail: `HTTP ${response.status}; expected signed-out rejection before provider action`,
+        };
+      }),
+    );
+  }
+
+  const observedAt = new Date();
+  return {
+    ok: checks.every(({ ok }) => ok),
+    appOrigin,
+    clerkHost,
+    observedAtUtc: observedAt.toISOString(),
+    observedAtLocal: observedAt.toLocaleString("en-US", { timeZoneName: "short" }),
+    checks,
+  };
+}
+
+function printHuman(report) {
+  console.log(
+    `Chrondle hosting parity doctor (${report.observedAtUtc} / ${report.observedAtLocal})`,
+  );
+  for (const check of report.checks) {
+    console.log(`${check.ok ? "PASS" : "FAIL"} ${check.name}: ${check.detail}`);
+  }
+  console.log(report.ok ? "PASS hosting parity" : "FAIL hosting parity");
+}
+
+async function main() {
+  const report = await verifyHostingParity();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHuman(report);
+  }
+  process.exitCode = report.ok ? 0 : 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/verify-hosting-parity.test.mjs
+++ b/scripts/verify-hosting-parity.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { verifyHostingParity } from "./verify-hosting-parity.mjs";
+
+const healthyFetch = async (url, init = {}) => {
+  const path = new URL(url).pathname;
+
+  if (path === "/v1/client") {
+    return new Response(JSON.stringify({ response: { client: {} } }), { status: 200 });
+  }
+  if (path === "/api/health") {
+    return new Response(
+      JSON.stringify({ status: "ok", checks: { convex: "ok", canary: "configured" } }),
+      { status: 200 },
+    );
+  }
+  if (path === "/sign-in") {
+    return new Response("<html>clerk.chrondle.app</html>", { status: 200 });
+  }
+  if (path === "/api/stripe/checkout" || path === "/api/stripe/portal") {
+    assert.equal(init.method, "POST");
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  throw new Error(`unexpected request: ${url}`);
+};
+
+const healthyConvexCorpus = async () => ({ totalPuzzles: 365, latestPuzzleDate: "2026-07-09" });
+
+test("passes the public auth, Convex, Canary, and charge-free Stripe boundary", async () => {
+  const report = await verifyHostingParity({
+    appOrigin: "https://chrondle.app",
+    clerkHost: "clerk.chrondle.app",
+    fetchImpl: healthyFetch,
+    resolveCname: async () => ["frontend-api.clerk.services"],
+    queryConvexCorpus: healthyConvexCorpus,
+  });
+
+  assert.equal(report.ok, true);
+  assert.deepEqual(
+    report.checks.map(({ name, ok }) => [name, ok]),
+    [
+      ["clerk-cname", true],
+      ["clerk-client", true],
+      ["convex-corpus", true],
+      ["app-health", true],
+      ["sign-in-route", true],
+      ["stripe-checkout-auth-boundary", true],
+      ["stripe-portal-auth-boundary", true],
+    ],
+  );
+});
+
+test("fails when the Clerk custom-domain CNAME disappears", async () => {
+  const report = await verifyHostingParity({
+    appOrigin: "https://chrondle.app",
+    clerkHost: "clerk.chrondle.app",
+    fetchImpl: healthyFetch,
+    resolveCname: async () => [],
+    queryConvexCorpus: healthyConvexCorpus,
+  });
+
+  assert.equal(report.ok, false);
+  assert.deepEqual(report.checks[0], {
+    name: "clerk-cname",
+    ok: false,
+    detail: "expected frontend-api.clerk.services; got no CNAME",
+  });
+});
+
+test("fails if a Stripe endpoint reaches provider logic while signed out", async () => {
+  const report = await verifyHostingParity({
+    appOrigin: "https://chrondle.app",
+    clerkHost: "clerk.chrondle.app",
+    resolveCname: async () => ["frontend-api.clerk.services"],
+    queryConvexCorpus: healthyConvexCorpus,
+    fetchImpl: async (url, init) => {
+      if (new URL(url).pathname === "/api/stripe/checkout") {
+        return new Response(JSON.stringify({ url: "https://checkout.stripe.com/session" }), {
+          status: 200,
+        });
+      }
+      return healthyFetch(url, init);
+    },
+  });
+
+  assert.equal(report.ok, false);
+  assert.equal(
+    report.checks.find(({ name }) => name === "stripe-checkout-auth-boundary").ok,
+    false,
+  );
+});
+
+test("fails if the Convex production corpus is empty", async () => {
+  const report = await verifyHostingParity({
+    appOrigin: "https://chrondle.app",
+    clerkHost: "clerk.chrondle.app",
+    resolveCname: async () => ["frontend-api.clerk.services"],
+    fetchImpl: healthyFetch,
+    queryConvexCorpus: async () => ({ totalPuzzles: 0, latestPuzzleDate: null }),
+  });
+
+  assert.equal(report.ok, false);
+  assert.equal(report.checks.find(({ name }) => name === "convex-corpus").ok, false);
+});

--- a/scripts/verify-hosting-parity.test.mjs
+++ b/scripts/verify-hosting-parity.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import { verifyHostingParity } from "./verify-hosting-parity.mjs";
 


### PR DESCRIPTION
## Summary

- add one production hosting-parity doctor for Clerk DNS/edge/sign-in, Convex corpus, app health, and signed-out Stripe boundaries
- test the missing-CNAME and provider-action escape regressions
- document the post-deployment probe

## Verification

- `bun run lint`
- `bun run type-check`
- `bun run test`
- `bunx vitest run scripts/verify-hosting-parity.test.mjs`
- `bun run doctor:hosting` against `https://chrondle.app` (green at 2026-07-10 00:36 UTC / 2026-07-09 19:36 CDT)

## Remaining acceptance gap

An authenticated production browser session is still required before starting the Vercel deletion soak. The approved Chrome binding is unavailable to this run, and no `TEST_USER_*` fixture credentials exist locally. No checkout, charge, or subscription mutation was attempted.